### PR TITLE
[FIF-178] Ignore self-signed certificate TLS errors in development mode

### DIFF
--- a/EdFi.Buzz.Api/.env.example
+++ b/EdFi.Buzz.Api/.env.example
@@ -1,3 +1,4 @@
+NODE_TLS_REJECT_UNAUTHORIZED='0' # '1' in production
 BUZZ_API_DB_HOST = 'localhost'
 BUZZ_API_DB_PORT = 5432
 BUZZ_API_DB_USERNAME ='postgres'

--- a/EdFi.Buzz.Api/src/main.ts
+++ b/EdFi.Buzz.Api/src/main.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import AppModule from './app.module';
@@ -11,6 +12,7 @@ const httpPort = parseInt(process.env.BUZZ_API_HTTP_PORT, 10);
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter());
+  Logger.log(`NODE_TLS_REJECT_UNAUTHORIZED := ${process.env.NODE_TLS_REJECT_UNAUTHORIZED}`);
   await app.listen(httpPort);
 }
 bootstrap();

--- a/EdFi.Buzz.UI.Angular/src/environments/environment.prod.ts
+++ b/EdFi.Buzz.UI.Angular/src/environments/environment.prod.ts
@@ -4,5 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 export const environment = {
-  production: true
+  production: true,
+  NODE_TLS_REJECT_UNAUTHORIZED: '1'
 };

--- a/EdFi.Buzz.UI.Angular/src/environments/environment.ts
+++ b/EdFi.Buzz.UI.Angular/src/environments/environment.ts
@@ -8,7 +8,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  NODE_TLS_REJECT_UNAUTHORIZED: '0'
 };
 
 /*

--- a/EdFi.Buzz.UI.Angular/src/main.ts
+++ b/EdFi.Buzz.UI.Angular/src/main.ts
@@ -29,9 +29,11 @@ fetch('assets/environment.json')
       }
       window['tempConfigStorage'] = config;
 
-      if (environment.production) {
-        enableProdMode();
-      }
+    if (environment.production) {
+      enableProdMode();
+    }
+
+    console.log(`NODE_TLS_REJECT_UNAUTHORIZED := ${environment.NODE_TLS_REJECT_UNAUTHORIZED}`);
 
       platformBrowserDynamic(providers).bootstrapModule(AppModule)
         .catch((err: any) => console.log(err));


### PR DESCRIPTION
Development clients do not always have self-signed certificates configured. This can cause an exception on the ApolloClient.

When applied, this PR will add environment variables for the Angular and API project to ignore the TLS client cert errors.

.env file for API adds a new environment variables  NODE_TLS_REJECT_UNAUTHORIZED set to 0 for development and 1 for production. Angular project's environment*.ts files introduce this same setting.

> **NOTE:** It was later determined that the VPN could also produce the 403 response. That error resulted before testing these changes, so the error message will be different.