### PR TITLE
[FIF-197] Give administrator users ability to upload surveys

### DIFF
--- a/EdFi.Buzz.Api/src/graphql/entities/staff.entity.ts
+++ b/EdFi.Buzz.Api/src/graphql/entities/staff.entity.ts
@@ -28,6 +28,8 @@ export default class StaffEntity {
 
   @Column() isadminsurveyloader: boolean;
 
+  @Column() isteachersurveyloader: boolean;
+
   @ManyToMany(() => SectionEntity, (section) => section.sectionkey)
   @JoinTable()
   sections?: SectionEntity[];

--- a/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
+++ b/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
@@ -76,6 +76,7 @@ type Staff
   staffuniqueid: String
   electronicmailaddress: String
   isadminsurveyloader: Boolean
+  isteachersurveyloader: Boolean
   section(sectionkey:String!): Section
   sections: [Section]
 }

--- a/EdFi.Buzz.Database/migrations/20200728093327-adds-isteachersurveyloader-column-to-staff-table.js
+++ b/EdFi.Buzz.Database/migrations/20200728093327-adds-isteachersurveyloader-column-to-staff-table.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728093327-adds-isteachersurveyloader-column-to-staff-table--up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728093327-adds-isteachersurveyloader-column-to-staff-table--down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/EdFi.Buzz.Database/migrations/sqls/20200728093327-adds-isteachersurveyloader-column-to-staff-table--down.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200728093327-adds-isteachersurveyloader-column-to-staff-table--down.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.Staff
+  DROP COLUMN IsTeacherSurveyLoader;

--- a/EdFi.Buzz.Database/migrations/sqls/20200728093327-adds-isteachersurveyloader-column-to-staff-table--up.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200728093327-adds-isteachersurveyloader-column-to-staff-table--up.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.Staff
+  ADD COLUMN IsTeacherSurveyLoader BOOLEAN NULL DEFAULT FALSE;

--- a/EdFi.Buzz.Etl/README.md
+++ b/EdFi.Buzz.Etl/README.md
@@ -19,31 +19,22 @@ That is it =)
 
 1. Download the repository.
 2. Install dependencies with `yarn install`.
-3. To configure the database, rename sample.env to .env and update the values to match your database configuration.
+3. To configure the database, rename .env.example to .env and update the values to match your database configuration.
 
-## How to run Survey ETL file directly in Node
+## Executing Survey Loader as a service to load files
 
-For testing with the survey sample data:
-    1. Use edfi.buzz.etl/surveySampleData/InsertSampleStudentData.sql to insert buzz.studentschool
-    2. edfi.buzz.etl/surveySampleData/* are example csv's to import that have studentkeys references to surveySampleData/InsertSampleStudentData.sql.
+Graphile Worker allows the Survey Loader  to run as a service. It will watch the graphile-worker jobs table in the edfi_buzz database for new jobs. The initial execution creates the required database schema objects needed to manage jobs. In production, the Project Buzz API will manage creating new survey jobs to process. Use the testing step below to add an individual survey for processing.
 
-```bash
-$ cd edfi.buzz.etl
-$ node ./src/surveyETL.js ./surveySampleData/InternetAccessSurvey.csv "Internet Access"
-```
-
-## How to run a Graphile Worker as a service to load Surveys
-
-Graphile Worker allows the ETL to run as a service. It will watch the graphile-worker jobs table for new jobs. The initial execution creates the required database schema objects needed to manage jobs. In production, the Project Buzz API will manage creating new survey jobs to process. Use the testing step below to add an individual survey for processing.
+The ETL Survey Loader can run as a service using the `yarn start:survey` task.
 
 ```bash
 $ cd edfi.buzz.etl
-$ npx graphile-worker -c "postgres://user:password@database.url:port/edfi_buzz"
+$ yarn start:survey
 ```
 
-### Testing the Survey Runner task manually
+### Create a Survey Loader job manually
 
-The surveyRunner task can execute a survey job manuall. Run the following SQL and replace the example staffkey,  survey name and file path location.
+The survey loader task can also load individual files manually. Run the following SQL and replace the example staffkey,  survey name and file path location.
 Once the graphile-worker is running, add a job using the following SQL in the edfi_buzz PostgreSQL database.
 
 ```sql
@@ -53,28 +44,30 @@ SELECT graphile_worker.add_job('surveyLoader', json_build_object('staffkey', '10
 The output should resemble the following:
 
 ```
-$ npx graphile-worker -c "postgresql://postgres:pa55w0rd@localhost/edfi_buzz"
+$ yarn start:survey
 [core] INFO: Worker connected and looking for jobs... (task names: 'surveyLoader')
 [job(worker-e7fec78d77f1c43645: surveyLoader{19})] INFO: Running the Survey loader for 1030 to load the Contact Survey located at file://c/dev/some.file
 [worker(worker-e7fec78d77f1c43645)] INFO: Completed task 19 (surveyLoader) with success (0.76ms)
 ```
 
-## How to run Database ETL
+## Running the Database Loader
 
-The database ETL module (./src/dbETL.js) is executed directly by node.
+The ETL Database module (./src/dbETL.js) is executed by yarn via the start:db task, or directly by node.
 
 ### PRECONDITIONS:
 
 - You have created a .env file, or renamed the sample.env and edited it to match your configuration.
-- You have a SQL Server install with an EdFi database with AMT views. If you want to load ODS only - update the - - BUZZ_SQLSOURCE value to 'ods' in your your .env file.
+- You have a SQL Server install with an EdFi database with AMT views. If you want to load ODS only - update the - BUZZ_SQLSOURCE value to 'ods' in your your .env file.
 - You have a Postgres local database called Buzz. (Run db-migrate up in the database sub).
 
-### Running the Database ETL
+### Running the Database Loader
 
-To run the database, navigate to the EdFi.Buzz.Etl directory, and execute ./src/dbEtl.js with node. Your output should look something like the following.
+To run the database, navigate to the EdFi.Buzz.Etl directory, and execute `yarn start:db`. Alternatively, you can run the `./src/dbEtl.js` file directly with node.
+
+Your output should look something like the following.
 
 ```powershell
-PS C:\dev\Ed-Fi\Buzz\edfi.buzz.etl> node ./src/dbEtl.js
+PS C:\dev\Ed-Fi\Buzz\edfi.buzz.etl> yarn start:db
 loading records from amt
 [School] loading....
 [School] Loaded records: 45
@@ -134,7 +127,7 @@ ODS_ENCRYPT=false
 
 ```powershell
 $ cd EdFi.Buzz.Etl
-$ node ./src/dbETL.js
+$ yarn start:db
 ```
 
 

--- a/EdFi.Buzz.Etl/package.json
+++ b/EdFi.Buzz.Etl/package.json
@@ -1,12 +1,14 @@
 {
   "scripts": {
     "lint": "eslint --fix \"./**/*.{js,jsx,ts,tsx}\"",
-    "lint:ci": "eslint \"./**/*.{js,jsx,ts,tsx}\" --format ./node_modules/eslint-teamcity/index.js"
+    "lint:ci": "eslint \"./**/*.{js,jsx,ts,tsx}\" --format ./node_modules/eslint-teamcity/index.js",
+    "start": "env-cmd -x npx graphile-worker -c \"postgresql://postgres:$BUZZ_PASSWORD@$BUZZ_DBSERVER/$BUZZ_DBNAME\""
   },
   "dependencies": {
     "babel-eslint": "^10.1.0",
     "csv-parser": "^2.3.3",
     "dotenv": "^8.2.0",
+    "env-cmd": "^10.1.0",
     "eslint": "^7.3.1",
     "etl": "^0.6.12",
     "fs": "^0.0.1-security",

--- a/EdFi.Buzz.Etl/package.json
+++ b/EdFi.Buzz.Etl/package.json
@@ -1,4 +1,7 @@
 {
+  "name":"edfi.buzz.etl",
+  "version": "0.1.0",
+  "private":true,
   "scripts": {
     "lint": "eslint --fix \"./**/*.{js,jsx,ts,tsx}\"",
     "lint:ci": "eslint \"./**/*.{js,jsx,ts,tsx}\" --format ./node_modules/eslint-teamcity/index.js",

--- a/EdFi.Buzz.Etl/package.json
+++ b/EdFi.Buzz.Etl/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "lint": "eslint --fix \"./**/*.{js,jsx,ts,tsx}\"",
     "lint:ci": "eslint \"./**/*.{js,jsx,ts,tsx}\" --format ./node_modules/eslint-teamcity/index.js",
-    "start": "env-cmd -x npx graphile-worker -c \"postgresql://postgres:$BUZZ_PASSWORD@$BUZZ_DBSERVER/$BUZZ_DBNAME\""
+    "start:survey": "env-cmd -x npx graphile-worker -c \"postgresql://postgres:$BUZZ_PASSWORD@$BUZZ_DBSERVER/$BUZZ_DBNAME\"",
+    "start:db": "node -r .\\src\\dbEtl.js"
   },
   "dependencies": {
     "babel-eslint": "^10.1.0",

--- a/EdFi.Buzz.Etl/processors/surveyProcessor.js
+++ b/EdFi.Buzz.Etl/processors/surveyProcessor.js
@@ -101,7 +101,7 @@ async function getOrSaveStudentSurvey(staffkey, surveykey, studentAnswers, db) {
   const studentkey = studentAnswers[STUDENT_SCHOOL_KEY_FIELD];
 
   const studentSchoolKeyRow = await db.query(
-    'SELECT DISTINCT s.studentschoolkey FROM buzz.studentschool s INNER JOIN buzz.studentsection ss ON s.studentschoolkey = ss.studentschoolkey INNER JOIN buzz.staffsectionassociation ssa ON ss.sectionkey = ssa.sectionkey WHERE s.studentkey = $1 AND ssa.staffkey = $2',
+    'SELECT DISTINCT s.studentschoolkey FROM buzz.studentschool s INNER JOIN buzz.studentsection ss ON s.studentschoolkey = ss.studentschoolkey INNER JOIN buzz.staffsectionassociation ssa ON ss.sectionkey = ssa.sectionkey WHERE s.studentkey = $1 AND ssa.staffkey = $2 AND EXISTS(SELECT staff.isteachersurveyloader FROM buzz.staff WHERE staff.staffkey=$2 AND staff.isteachersurveyloader = TRUE) UNION SELECT DISTINCT s.studentschoolkey FROM buzz.studentschool s INNER JOIN buzz.studentsection ss ON s.studentschoolkey = ss.studentschoolkey CROSS JOIN buzz.staff staff WHERE s.studentkey = $1 AND (staff.staffkey = $2 and staff.isadminsurveyloader = true)',
     [studentkey, staffkey],
   );
   if (studentSchoolKeyRow.rows.length === 0) {

--- a/EdFi.Buzz.Etl/yarn.lock
+++ b/EdFi.Buzz.Etl/yarn.lock
@@ -603,6 +603,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -644,7 +649,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -836,6 +841,14 @@ enquirer@^2.3.5:
   integrity sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==
   dependencies:
     ansi-colors "^3.2.1"
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"

--- a/EdFi.Buzz.UI.Angular/src/app/Features/navbar/navbar.component.html
+++ b/EdFi.Buzz.UI.Angular/src/app/Features/navbar/navbar.component.html
@@ -9,7 +9,7 @@
           Welcome, {{teacher.firstname}} <i class="icon ion-md-person"></i>
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown" style="position: absolute;">
-          <a *ngIf="teacher.isadminsurveyloader" [routerLink]="['/app/uploadSurvey']" class="dropdown-item" ><i class="icon ion-md-cloud-upload"></i> Upload survey</a>
+          <a *ngIf="teacher.isadminsurveyloader || teacher.isteachersurveyloader" [routerLink]="['/app/uploadSurvey']" class="dropdown-item" ><i class="icon ion-md-cloud-upload"></i> Upload survey</a>
           <a class="dropdown-item" (click)="signOut();"><i class="icon ion-md-unlock"></i> Log out</a>
         </div>
       </li>

--- a/EdFi.Buzz.UI.Angular/src/app/Interceptors/auth.guard.ts
+++ b/EdFi.Buzz.UI.Angular/src/app/Interceptors/auth.guard.ts
@@ -32,7 +32,9 @@ export class AuthGuard implements CanActivate {
         const currentUser = this.authenticationService.currentUserValue;
         if (currentUser) {
             const roles = route.data && route.data.roles ? route.data.roles : [];
-            const userRol = currentUser.teacher && currentUser.teacher.isadminsurveyloader === true ? 'surveyUploader' : '';
+          const userRol = currentUser.teacher &&
+              (currentUser.teacher.isadminsurveyloader === true || currentUser.teacher.isteachersurveyloader === true) ?
+              'surveyUploader' : '';
             const allowed = roles.length === 0 || roles.includes(userRol);
             // logged in so return true
             return allowed;

--- a/EdFi.Buzz.UI.Angular/src/app/Models/teacher.ts
+++ b/EdFi.Buzz.UI.Angular/src/app/Models/teacher.ts
@@ -15,6 +15,7 @@ export class Teacher {
   middlename: string;
   electronicmailaddress: string;
   isadminsurveyloader: boolean;
+  isteachersurveyloader: boolean;
 
   constructor() {
     this.sections = [];

--- a/EdFi.Buzz.UI.Angular/src/app/Services/GraphQL/staffQueries.ts
+++ b/EdFi.Buzz.UI.Angular/src/app/Services/GraphQL/staffQueries.ts
@@ -14,6 +14,7 @@ query($staffkey:ID!){
     firstname
     middlename
     electronicmailaddress
+    isteachersurveyloader
     isadminsurveyloader
     sections{
       sectionkey
@@ -35,6 +36,7 @@ query($staffkey:ID!){
     middlename
     electronicmailaddress
     isadminsurveyloader
+    isteachersurveyloader
   }
 }
 `;
@@ -49,6 +51,7 @@ query {
     middlename
     electronicmailaddress
     isadminsurveyloader
+    isteachersurveyloader
     sections {
       sectionkey
       localcoursecode


### PR DESCRIPTION
## OVERVIEW
When this PR is applied, it will allow admin users to upload surveys for all students without restrictions. Existing functionality for teachers should continue to restrict the target of their updates to only their students.

The PR makes the following modifications:
- adds a isteachersurveyloader boolean column to the staff table via a new database migration.
- replaces the original usages of isadminsurveyloader with isteachersurveyloader
- updates navigation for survey loader menu to check permissions for both teachers and administrator survey loaders.
- updates the ETL's survey processor query for when to update a student with a union query for staff with the survey loading administrator user permission set to true. And it updates the original teacher query to replace the admin permission with the new teacher permission.

## TESTING

We will want to test the following
- Given a staff users where isadminsurveyloader is false and isteachersurveyloader is false, when the user clicks the Profile menu drop down navigation, it should not show the "Upload survey" nav link. 
- Given a staff users where isadminsurveyloader is false and isteachersurveyloader is false, when the user enters the direct URL to "/#/app/uploadSurvey", it should not allow the user to see that page. 
- Given a staff user where isadminsurveyloader is true, when they upload any file, it should load all records with no errors.
- Given a staff user where isadminsurveyloader is false but isteachersurveyloader is true, when they upload a file containing their students, it should load all records with no errors.
- Given a staff user where isadminsurveyloader is false but isteachersurveyloader is true, when they upload a file that does not contain their students, it should NOT load any records and it should report each student key as an error.

Testing requires an admin user who can upload surveys. To add your email as an admin user, change the values to your email and name in the SQL below,  then run the following in a PL\PGSQL SQL manager (I used HeidiSQL).
```sql
-- Create an admin record for your user account
DO 
$$
DECLARE 
	next_id integer;
BEGIN
SELECT MAX(staffkey) + 1 INTO next_id FROM buzz.staff;
INSERT INTO buzz.staff (staffkey, firstname, middlename, lastsurname, staffuniqueid, electronicmailaddress, isadminsurveyloader) VALUES (next_id , '<YOUR NAME>', '', '<YOUR NAME>', SUBSTRING(CAST(gen_random_uuid() AS varchar),1,32), '<YOUR EMAIL>', 'true');
END $$;
```
Next, you will want to have records for the projectbuzzdemo@gmail.com user. Get the staff key for the staff for whom you have assigned the Project Buzz Demo email.

Export these results to a file for your Project Buzz Demo user, and again as a different staffkey:
```sql
-- CREATE A SAMPLE CONTACT SURVEY
SELECT DISTINCT NOW() AS "Timestamp", s.studentkey AS "StudentUniqueId", s.studentfirstname AS "FirstName", s.studentlastname AS "LastSurname", 'Phone' AS "Preferred contact method", 'After 6pm' AS "Best time to contact", 'Speak loud' AS "Contact notes"
FROM buzz.studentschool s
INNER JOIN buzz.studentsection ss ON s.studentschoolkey = ss.studentschoolkey
INNER JOIN buzz.staffsectionassociation ssa ON ss.sectionkey = ssa.sectionkey
WHERE
ssa.staffkey = 1030 -- where staffkey is for projectbuzzdemo@gmail.com
```
