### PR TITLE
[FIF-198] Soft delete student notes - backend

### DIFF
--- a/EdFi.Buzz.Api/src/graphql/entities/studentnote.entity.ts
+++ b/EdFi.Buzz.Api/src/graphql/entities/studentnote.entity.ts
@@ -18,4 +18,8 @@ export default class StudentNoteEntity {
   @Column() staffkey: number;
 
   @Column() dateadded?: string;
+
+  @Column() deletedat?: string;
+
+  @Column() deletedby?: number;
 }

--- a/EdFi.Buzz.Api/src/graphql/graphql.schema.ts
+++ b/EdFi.Buzz.Api/src/graphql/graphql.schema.ts
@@ -35,6 +35,8 @@ export class ContactPerson {
 export abstract class IMutation {
     abstract addstudentnote(staffkey: number, studentschoolkey: string, note: string): StudentNote | Promise<StudentNote>;
 
+    abstract deletestudentnote(staffkey: number, studentnotekey: number): StudentNote | Promise<StudentNote>;
+
     abstract uploadsurvey(staffkey: string, title: string, content: string): string | Promise<string>;
 }
 
@@ -89,6 +91,7 @@ export class Staff {
     lastsurname?: string;
     staffuniqueid?: string;
     electronicmailaddress?: string;
+    isadminsurveyloader?: boolean;
     section?: Section;
     sections?: Section[];
 }

--- a/EdFi.Buzz.Api/src/graphql/resolvers/studentnote.resolver.ts
+++ b/EdFi.Buzz.Api/src/graphql/resolvers/studentnote.resolver.ts
@@ -26,4 +26,17 @@ export default class StudentNoteResolvers {
       staffkey,
     });
   }
+
+  @Mutation('deletestudentnote')
+  async deletestudentnote(@Args('staffkey') staffkey: number,
+    @Args('studentnotekey') studentnotekey: number): Promise<StudentNote> {
+    const deletedby = staffkey;
+    return this.studentNoteService.deleteStudentNote({
+      studentnotekey,
+      note: null,
+      studentschoolkey: null,
+      staffkey: null,
+      deletedby,
+    });
+  }
 }

--- a/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
+++ b/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
@@ -55,8 +55,6 @@ type StudentNote {
   studentschoolkey: String
   staffkey: Int
   dateadded: String
-  deletedat: String
-  deletedby: String
 }
 
 type StudentSurvey{

--- a/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
+++ b/EdFi.Buzz.Api/src/graphql/schema/schema.graphql
@@ -5,6 +5,7 @@
 
 type Mutation {
   addstudentnote(staffkey: Int!, studentschoolkey: String!, note: String!): StudentNote
+  deletestudentnote(staffkey: Int!, studentnotekey: Int!): StudentNote
   uploadsurvey(staffkey: ID!, title: String!, content: String!): String
 }
 type Query{
@@ -54,6 +55,8 @@ type StudentNote {
   studentschoolkey: String
   staffkey: Int
   dateadded: String
+  deletedat: String
+  deletedby: String
 }
 
 type StudentSurvey{

--- a/EdFi.Buzz.Api/src/graphql/services/studentnote.service.ts
+++ b/EdFi.Buzz.Api/src/graphql/services/studentnote.service.ts
@@ -18,4 +18,13 @@ export default class StudentNoteService {
   async addStudentNote(note: StudentNoteEntity): Promise<StudentNoteEntity> {
     return this.BuzzStudentNotesRepository.save(note);
   }
+
+  async deleteStudentNote(note: StudentNoteEntity): Promise<StudentNoteEntity> {
+    const d = new Date();
+    const datestring = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+    const noteToDelete = await this.BuzzStudentNotesRepository.findOne(note.studentnotekey);
+    noteToDelete.deletedby = note.deletedby;
+    noteToDelete.deletedat = datestring;
+    return this.BuzzStudentNotesRepository.save(noteToDelete);
+  }
 }

--- a/EdFi.Buzz.Api/src/graphql/services/studentschool.service.ts
+++ b/EdFi.Buzz.Api/src/graphql/services/studentschool.service.ts
@@ -102,7 +102,7 @@ export default class SectionService {
         'ss',
         `studentnotes.studentschoolkey = ss.studentschoolkey and ss.studentschoolkey='${studentschoolkey}'`,
       )
-      .where({ studentschoolkey })
+      .where('(studentnotes.deletedat IS NULL)')
       .orderBy('studentnotekey', 'DESC')
       .getMany();
   }

--- a/EdFi.Buzz.Database/migrations/20200728092015-adds-delete_at-colum-to-studentnote-table.js
+++ b/EdFi.Buzz.Database/migrations/20200728092015-adds-delete_at-colum-to-studentnote-table.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728092015-adds-delete_at-colum-to-studentnote-table-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728092015-adds-delete_at-colum-to-studentnote-table-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/EdFi.Buzz.Database/migrations/sqls/20200728092015-adds-delete_at-colum-to-studentnote-table-down.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200728092015-adds-delete_at-colum-to-studentnote-table-down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.StudentNote
+  DROP COLUMN deletedat,
+  DROP COLUMN deletedby;

--- a/EdFi.Buzz.Database/migrations/sqls/20200728092015-adds-delete_at-colum-to-studentnote-table-up.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200728092015-adds-delete_at-colum-to-studentnote-table-up.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.StudentNote
+  ADD COLUMN deletedat date NULL,
+  ADD COLUMN deletedby int NULL;


### PR DESCRIPTION
- Two columns were added to StudentNote:
 1. deletedat: The date it was deleted.
 2. deletedby: The staffkey of who deleted it.
- Deletestudentnote method added to do the API.
- The notes query was modified to return only those that do not have a deletion date.