### PR TITLE
[FIF-243] Last uploaded survey session storage value, deleted after logout

### DIFF
--- a/EdFi.Buzz.UI.Angular/src/app/Services/authentication.service.ts
+++ b/EdFi.Buzz.UI.Angular/src/app/Services/authentication.service.ts
@@ -46,6 +46,7 @@ export class AuthenticationService {
   logout() {
     // remove user from local storage to log user out
     this.storage.removeItem('currentUser');
+    this.storage.removeItem('lastUploadedSurvey');
     this.currentUserSubject.next(null);
     // clear graphql cache
     ApolloHelper.clearApolloStorage(this.apollo.getClient());


### PR DESCRIPTION
1. Login to the app.
2. Open browser console.
3. Go to Application/Session Storage
4. It should contain only CurrentUser key
![init](https://user-images.githubusercontent.com/56046999/90832361-d74fea80-e302-11ea-8bfa-dedbd40d44c5.PNG)

5. Upload a new file.
6. Now, Session Storage should contain two keys: CurrentUser and lastUploadedSurvey.
![02](https://user-images.githubusercontent.com/56046999/90832375-dc149e80-e302-11ea-8b10-4d269b7b4f52.PNG)

7. Logout
8. Session Storage should be empty.
![03](https://user-images.githubusercontent.com/56046999/90832384-e040bc00-e302-11ea-9b51-7f54fad65bc5.PNG)
9. If you log in again, the last survey uploaded will no longer be on local storage.