### PR TITLE
[FIF-237] Fix chart-js clipping on the tooltip on surveys

### DIFF
--- a/EdFi.Buzz.UI.Angular/src/app/Features/SurveyAnalyticsReact/surveyChart.tsx
+++ b/EdFi.Buzz.UI.Angular/src/app/Features/SurveyAnalyticsReact/surveyChart.tsx
@@ -51,6 +51,14 @@ export const SurveyChart: React.FunctionComponent<SurveyChartComponentProps> = (
       };
     },
     options: {
+      layout: {
+        padding: {
+            left: 0,
+            right: 10,
+            top: 0,
+            bottom: 0
+        }
+      },
       responsive: true,
       maintainAspectRatio: false,
       scales: {


### PR DESCRIPTION
The survey page is clipping the right side of the tooltip.

![image](https://user-images.githubusercontent.com/63315476/91197741-5194bc00-e6c1-11ea-8002-b934f7358dde.png)

This PR will add a layout option configuration to add some padding to the right side. To look as it does below...

![image](https://user-images.githubusercontent.com/63315476/91197898-8143c400-e6c1-11ea-92ae-80ee517d53fc.png)


