### PR TITLE
[FIF-155] Configurable Note visibility - Schema Update

### DIFF
--- a/EdFi.Buzz.Database/migrations/20200827142743-adds-note-visibility.js
+++ b/EdFi.Buzz.Database/migrations/20200827142743-adds-note-visibility.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200827142743-adds-note-visibility-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200827142743-adds-note-visibility-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/EdFi.Buzz.Database/migrations/sqls/20200827142743-adds-note-visibility-down.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200827142743-adds-note-visibility-down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.studentnote DROP COLUMN visibleonlytoauthor;

--- a/EdFi.Buzz.Database/migrations/sqls/20200827142743-adds-note-visibility-up.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20200827142743-adds-note-visibility-up.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+ALTER TABLE buzz.studentnote ADD visibleonlytoauthor boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
Adds the field `visibleonlytoauthor` to set the visibility of the note:
* false: default, visible to all staff that can view the student's details.
* true: Only visible to the note's author.

## Test
* Run `yarn migrate` in the `EdFi.Buzz.Database` directory.
* In app: 
  * Add a note to a student. *Should not fail*.
  * Delete a note from a student. *Should not fail*.