### PR TITLE
[FIF-279] Use watchall to run tests non-interactively

### DIFF
--- a/EdFi.Buzz.UI/package.json
+++ b/EdFi.Buzz.UI/package.json
@@ -57,7 +57,7 @@
     "lint": "eslint --fix \"src/**/*{ts,tsx}\"",
     "lint:ci": "yarn lint --format ./node_modules/eslint-teamcity/index.js ",
     "test": "react-scripts test",
-    "test:ci": "react-scripts test --ci --watch=false --browsers=ChromeHeadless",
+    "test:ci": "react-scripts test --ci --watchAll=false --browsers=ChromeHeadless",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
The builds were running for hours because react-scripts tests were running interactively on TeamCity - awaiting user input.

This commit will change `--watch=false` to `--watchAll=false` to run tests non-interactively.