### PR TITLE
[FIF-279] Show warn instead of error on eslint issues

### DIFF
--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -95,9 +95,10 @@
         }
       }
     ],
-    "@typescript-eslint/member-ordering": "error",
+    "@typescript-eslint/member-ordering": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-explicit-any": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-inferrable-types": [
       "error",
       {
@@ -105,9 +106,10 @@
       }
     ],
     "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-non-null-assertion": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-unused-expressions": "error",
-    "@typescript-eslint/no-use-before-define": [1],
+    "@typescript-eslint/no-unused-vars": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-use-before-define": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/quotes": [
       "error",
@@ -134,6 +136,7 @@
     "guard-for-in": "error",
     "id-blacklist": "off",
     "id-match": "off",
+    "import/no-cycle": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "import/no-deprecated": "warn",
     "import/prefer-default-export": "off",
     "max-len": [
@@ -179,6 +182,7 @@
       "error",
       "rxjs/Rx"
     ],
+    "no-return-assign": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "no-shadow": [
       "error",
       {

--- a/EdFi.Buzz.UI/package.json
+++ b/EdFi.Buzz.UI/package.json
@@ -12,6 +12,7 @@
     "bootstrap": "^4.5.2",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
+    "jest-teamcity-reporter": "^0.9.0",
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.16.1",
     "react": "^16.13.1",
@@ -67,7 +68,7 @@
     "lint": "eslint --fix \"src/**/*{ts,tsx}\"",
     "lint:ci": "yarn lint --format ./node_modules/eslint-teamcity/index.js ",
     "test": "react-scripts test",
-    "test:ci": "react-scripts test --ci --watchAll=false --browsers=ChromeHeadless",
+    "test:ci": "react-scripts test --ci --env=jsdom --testResultsProcessor=jest-teamcity-reporter --watchAll=false --browsers=ChromeHeadless",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject"
   },

--- a/EdFi.Buzz.UI/yarn.lock
+++ b/EdFi.Buzz.UI/yarn.lock
@@ -6959,6 +6959,11 @@ jest-snapshot@^24.9.0:
     pretty-format "^24.9.0"
     semver "^6.2.0"
 
+jest-teamcity-reporter@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/jest-teamcity-reporter/-/jest-teamcity-reporter-0.9.0.tgz#a9f337a928a14e7e84163817456b930ecf7cbce8"
+  integrity sha512-q6W+ZaJSCIXmxC9wsY67zNn+vwG/EgKJygYJYH860jih5zS6mc2ZFc4v78gh6rgzgM9/siUtQm7SnRunYuWmVw==
+
 jest-util@^24.0.0, jest-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"


### PR DESCRIPTION
React's eslint rules configuration is has more restrictions than what we had on Angular. This PR will change the current errors into warnings, and add TODO comments to the eslintrc.json. The task to fix linting issues #FIF-302 was documented with all of these rules changes.