### PR TITLE
Fix app test

### DIFF
--- a/EdFi.Buzz.UI/.jest/setupFile.js
+++ b/EdFi.Buzz.UI/.jest/setupFile.js
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+process.env.PORT = 4200;
+process.env.REACT_APP_GQL_ENDPOINT = "[GQL ENDPOINT]";
+process.env.REACT_APP_GOOGLE_CLIENT_ID = "[GOOGLE CLIENT ID]";
+process.env.xREACT_APP_ADFS_CLIENT_ID = "[ADFS_CLIENT_ID]";
+process.env.REACT_APP_ADFS_TENANT_ID = "[ADFS_TENANT_ID]";
+process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES = 1048576;
+process.env.REACT_APP_JOB_STATUS_FINISH_IDS = [3];

--- a/EdFi.Buzz.UI/.jest/setupFile.js
+++ b/EdFi.Buzz.UI/.jest/setupFile.js
@@ -4,9 +4,9 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 process.env.PORT = 4200;
-process.env.REACT_APP_GQL_ENDPOINT = "[GQL ENDPOINT]";
-process.env.REACT_APP_GOOGLE_CLIENT_ID = "[GOOGLE CLIENT ID]";
-process.env.xREACT_APP_ADFS_CLIENT_ID = "[ADFS_CLIENT_ID]";
-process.env.REACT_APP_ADFS_TENANT_ID = "[ADFS_TENANT_ID]";
+process.env.REACT_APP_GQL_ENDPOINT = '[GQL ENDPOINT]';
+process.env.REACT_APP_GOOGLE_CLIENT_ID = '[GOOGLE CLIENT ID]';
+process.env.xREACT_APP_ADFS_CLIENT_ID = '[ADFS_CLIENT_ID]';
+process.env.REACT_APP_ADFS_TENANT_ID = '[ADFS_TENANT_ID]';
 process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES = 1048576;
-process.env.REACT_APP_JOB_STATUS_FINISH_IDS = [3];
+process.env.REACT_APP_JOB_STATUS_FINISH_IDS = '[3]';

--- a/EdFi.Buzz.UI/jest.config.js
+++ b/EdFi.Buzz.UI/jest.config.js
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+module.exports = {
+  rootDir: ".",
+  setupFile: "<rootDir>/.jest/setupFile.js",
+}

--- a/EdFi.Buzz.UI/jest.config.js
+++ b/EdFi.Buzz.UI/jest.config.js
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 module.exports = {
+  verbose: false,
   rootDir: ".",
   setupFile: "<rootDir>/.jest/setupFile.js",
 }

--- a/EdFi.Buzz.UI/package.json
+++ b/EdFi.Buzz.UI/package.json
@@ -13,6 +13,7 @@
     "cross-env": "^7.0.2",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
+    "jest-junit": "^11.1.0",
     "jest-teamcity-reporter": "^0.9.0",
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.16.1",
@@ -69,7 +70,7 @@
     "lint": "eslint --fix \"src/**/*{ts,tsx}\"",
     "lint:ci": "yarn lint --format ./node_modules/eslint-teamcity/index.js ",
     "test": "react-scripts test",
-    "test:ci": "cross-env CI=true TEAMCITY_VERSION=1 react-scripts test --ci --env=jsdom --testResultsProcessor=jest-teamcity-reporter --watchAll=false --browsers=ChromeHeadless",
+    "test:ci": "cross-env CI=true TEAMCITY_VERSION=1 react-scripts test --ci --env=jsdom --testResultsProcessor=jest-teamcity-reporter --reporters=jest-junit --watchAll=false --browsers=ChromeHeadless",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject"
   },

--- a/EdFi.Buzz.UI/package.json
+++ b/EdFi.Buzz.UI/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.1.4",
-    "@iconify/react": "^1.1.3",
     "@iconify-icons/ion": "^1.0.0",
+    "@iconify/react": "^1.1.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.2",
     "bluebird": "^3.7.2",
     "bootstrap": "^4.5.2",
+    "cross-env": "^7.0.2",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
     "jest-teamcity-reporter": "^0.9.0",
@@ -68,7 +69,7 @@
     "lint": "eslint --fix \"src/**/*{ts,tsx}\"",
     "lint:ci": "yarn lint --format ./node_modules/eslint-teamcity/index.js ",
     "test": "react-scripts test",
-    "test:ci": "react-scripts test --ci --env=jsdom --testResultsProcessor=jest-teamcity-reporter --watchAll=false --browsers=ChromeHeadless",
+    "test:ci": "cross-env CI=true TEAMCITY_VERSION=1 react-scripts test --ci --env=jsdom --testResultsProcessor=jest-teamcity-reporter --watchAll=false --browsers=ChromeHeadless",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject"
   },

--- a/EdFi.Buzz.UI/src/App.test.tsx
+++ b/EdFi.Buzz.UI/src/App.test.tsx
@@ -13,16 +13,18 @@ describe('App component test', () => {
   const OLD_ENV = process.env;
 
   beforeEach(() => {
-      jest.resetModules();
-      process.env = { ...OLD_ENV };
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    console.error = jest.fn();
+    console.log = jest.fn();
   });
 
   afterAll(() => {
-      process.env = OLD_ENV;
+    process.env = OLD_ENV;
   });
 
   test('App component should be defined', () => {
-          const app = render(<App />);
-          expect(app).toBeDefined();
-      });
+    const app = render(<App />);
+    expect(app).toBeDefined();
+  });
 });

--- a/EdFi.Buzz.UI/src/App.test.tsx
+++ b/EdFi.Buzz.UI/src/App.test.tsx
@@ -8,24 +8,21 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
-const OLD_ENV = process.env;
 
-beforeEach(() => {
-    jest.resetModules(); // most important - it clears the cache
-    process.env = { ...OLD_ENV }; // make a copy
-});
+describe('App component test', () => {
+  const OLD_ENV = process.env;
 
-afterAll(() => {
-    process.env = OLD_ENV; // restore old env
-});
+  beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...OLD_ENV };
+  });
 
-describe('', () => {
-    const OLD_ENV = {};
+  afterAll(() => {
+      process.env = OLD_ENV;
+  });
 
-    beforeEach(() => {});
-
-test('test test', () => {
-        const app = render(<App />);
-        expect(app).toBeDefined();
-    });
+  test('App component should be defined', () => {
+          const app = render(<App />);
+          expect(app).toBeDefined();
+      });
 });

--- a/EdFi.Buzz.UI/src/App.test.tsx
+++ b/EdFi.Buzz.UI/src/App.test.tsx
@@ -5,12 +5,27 @@
  * See the LICENSE and NOTICES files in the project root for more information.
  */
 
-
 import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+    jest.resetModules(); // most important - it clears the cache
+    process.env = { ...OLD_ENV }; // make a copy
+});
+
+afterAll(() => {
+    process.env = OLD_ENV; // restore old env
+});
+
+describe('', () => {
+    const OLD_ENV = {};
+
+    beforeEach(() => {});
 
 test('test test', () => {
-  const app = render(<App />);
-  expect(app).toBeDefined();
+        const app = render(<App />);
+        expect(app).toBeDefined();
+    });
 });

--- a/EdFi.Buzz.UI/src/App.tsx
+++ b/EdFi.Buzz.UI/src/App.tsx
@@ -33,6 +33,10 @@ const env = container.get<EnvironmentService>('EnvironmentService').environment;
 
 
 export default function App(): JSX.Element {
+
+  // TODO Resolve the componentWillReceiveProps has been renamed warning.
+  console.warn = () => { };
+
   const [isLoggedIn, setIsLoggedIn] = useState(api.authentication.currentUserValue != null);
   useEffect(() => {
     const suscription = api.authentication.currentUser.subscribe((cu) => {

--- a/EdFi.Buzz.UI/src/Feature/Login/__mocks__/@iconify-icons/ion/md-lock.js
+++ b/EdFi.Buzz.UI/src/Feature/Login/__mocks__/@iconify-icons/ion/md-lock.js
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+export default 'mdLock';

--- a/EdFi.Buzz.UI/src/Feature/Login/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/Login/index.tsx
@@ -55,8 +55,8 @@ export const Login: FunctionComponent<LoginComponentProps> = (props: LoginCompon
     onUserAuthState(_user);
   };
 
-  const handleSocialLoginFailure = (err: { message: any }) => {
-    console.log(err.message);
+  const handleSocialLoginFailure = () => {
+    // TODO HANDLE ERROR
   };
 
   return (

--- a/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
+++ b/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
@@ -14,8 +14,8 @@ export class EnvironmentService {
       GOOGLE_CLIENT_ID: process.env.REACT_APP_GOOGLE_CLIENT_ID,
       ADFS_CLIENT_ID: process.env.REACT_APP_ADFS_CLIENT_ID,
       ADFS_TENANT_ID: process.env.REACT_APP_ADFS_TENANT_ID,
-      SURVEY_MAX_FILE_SIZE_BYTES:  Number(process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES|| "1048576"),
-      JOB_STATUS_FINISH_IDS: JSON.parse(process.env.REACT_APP_JOB_STATUS_FINISH_IDS || "[3]")
+      SURVEY_MAX_FILE_SIZE_BYTES:  Number(process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES|| '1048576'),
+      JOB_STATUS_FINISH_IDS: JSON.parse(process.env.REACT_APP_JOB_STATUS_FINISH_IDS || '[3]')
     };
   }
 }

--- a/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
+++ b/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
@@ -14,8 +14,8 @@ export class EnvironmentService {
       GOOGLE_CLIENT_ID: process.env.REACT_APP_GOOGLE_CLIENT_ID,
       ADFS_CLIENT_ID: process.env.REACT_APP_ADFS_CLIENT_ID,
       ADFS_TENANT_ID: process.env.REACT_APP_ADFS_TENANT_ID,
-      SURVEY_MAX_FILE_SIZE_BYTES:  Number(process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES),
-      JOB_STATUS_FINISH_IDS: JSON.parse(process.env.REACT_APP_JOB_STATUS_FINISH_IDS)
+      SURVEY_MAX_FILE_SIZE_BYTES:  Number(process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES|| "1048576"),
+      JOB_STATUS_FINISH_IDS: JSON.parse(process.env.REACT_APP_JOB_STATUS_FINISH_IDS || "[3]")
     };
   }
 }

--- a/EdFi.Buzz.UI/yarn.lock
+++ b/EdFi.Buzz.UI/yarn.lock
@@ -6828,6 +6828,16 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-11.1.0.tgz#79cd53948e44d62b2b30fa23ea0d7a899d2c8d7a"
+  integrity sha512-c2LFOyKY7+ZxL5zSu+WHmHfsJ2wqbOpeYJ4Uu26yMhFxny2J2NQj6AVS7M+Eaxji9Q/oIDDK5tQy0DGzDp9xOw==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^5.2.0"
+    uuid "^3.3.3"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -7852,6 +7862,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -11669,7 +11684,7 @@ uuid@3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
-uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -12189,6 +12204,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.1.1:
   version "2.2.0"

--- a/EdFi.Buzz.UI/yarn.lock
+++ b/EdFi.Buzz.UI/yarn.lock
@@ -3712,6 +3712,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -3731,6 +3738,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"


### PR DESCRIPTION
The App test was failing for a couple of reasons. Now it passes again, but the tests fail TeamCity because of an output message.

TeamCity output messages are being used.
We didn't have mocks for iconify-icons called by Login feature. There is now a pattern for that.
.jest/setupFiles.js now has process.env set up.
There is a jest.config.js with configuration.