### PR TITLE
[FIF-305] Updating Angular to node-forge@0.10.0

### DIFF
--- a/EdFi.Buzz.UI.Angular/package.json
+++ b/EdFi.Buzz.UI.Angular/package.json
@@ -86,5 +86,8 @@
   },
   "peerDependencies": {
     "react-is": "^16.13.1"
+  },
+  "resolutions": {
+    "node-forge": "^0.10.0"
   }
 }

--- a/EdFi.Buzz.UI.Angular/yarn.lock
+++ b/EdFi.Buzz.UI.Angular/yarn.lock
@@ -5919,10 +5919,10 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-forge@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
-  integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+node-forge@0.9.0, node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp@^3.8.0:
   version "3.8.0"


### PR DESCRIPTION
node-forge has a high severity issue. It is in the yarn.lock for Angular. We have a transitive dependency on the package. We can use selective dependency resolution to force the upgrade.

Used [this](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) as a guide to update this dependency.