### PR TITLE
[FIF-298] Create initial folder structure for Buzz Installer

### DIFF
--- a/.teamcity/Installer/Project.kt
+++ b/.teamcity/Installer/Project.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+package installer
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+
+object UIProject : Project({
+    id("Buzz_Installer")
+    name = "Installer"
+    description = "Buzz App Installer"
+
+    buildType(ui.buildTypes.PullRequestUIBuild)
+    buildType(ui.buildTypes.BranchInstallerBuild)
+    buildType(ui.buildTypes.DeployInstallerBuild)
+
+    params{
+        param("project.directory", "./EdFi.Buzz.Installer");
+        param("octopus.release.version","<placeholder value>")
+        param("octopus.release.project", "Project Buzz")
+        param("octopus.project.id", "Projects-112")
+        param("vcs.checkout.rules","""
+            +:.teamcity => .teamcity
+            +:%project.directory% => %project.directory%
+        """.trimIndent())
+    }
+})

--- a/.teamcity/Installer/Project.kt
+++ b/.teamcity/Installer/Project.kt
@@ -7,14 +7,14 @@ package installer
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 
-object UIProject : Project({
+object InstallerProject : Project({
     id("Buzz_Installer")
     name = "Installer"
     description = "Buzz App Installer"
 
-    buildType(ui.buildTypes.PullRequestUIBuild)
-    buildType(ui.buildTypes.BranchInstallerBuild)
-    buildType(ui.buildTypes.DeployInstallerBuild)
+    buildType(installer.buildTypes.PullRequestUIBuild)
+    buildType(installer.buildTypes.BranchInstallerBuild)
+    buildType(installer.buildTypes.DeployInstallerBuild)
 
     params{
         param("project.directory", "./EdFi.Buzz.Installer");

--- a/.teamcity/Installer/Project.kt
+++ b/.teamcity/Installer/Project.kt
@@ -12,7 +12,7 @@ object InstallerProject : Project({
     name = "Installer"
     description = "Buzz App Installer"
 
-    buildType(installer.buildTypes.PullRequestUIBuild)
+    buildType(installer.buildTypes.PullRequestInstallerBuild)
     buildType(installer.buildTypes.BranchInstallerBuild)
     buildType(installer.buildTypes.DeployInstallerBuild)
 

--- a/.teamcity/Installer/buildTypes/BranchInstallerBuild.kt
+++ b/.teamcity/Installer/buildTypes/BranchInstallerBuild.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+package installer.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+
+object BranchInstallerBuild : BuildType ({
+    name = "Branch Build and Test"
+    templates(_self.templates.BuildAndTestTemplate)
+})

--- a/.teamcity/Installer/buildTypes/DeployInstaller.kt
+++ b/.teamcity/Installer/buildTypes/DeployInstaller.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+package installer.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nuGetPublish
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
+
+
+object DeployInstallerBuild : BuildType ({
+    name = "Deploy"
+
+    features {
+        // Default setting is to clean before next build
+        swabra {
+        }
+    }
+
+    dependencies {
+        artifacts(BranchInstallerBuild) {
+            buildRule = lastSuccessful()
+            artifactRules = "+:*-pre*.nupkg"
+        }
+    }
+
+    steps {
+        nuGetPublish {
+            name = "Publish NuGet Packages to Octopus Feed"
+            toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
+            packages = "**/*.nupkg"
+            serverUrl = "%octopus.server.nugetFeed%"
+            apiKey = "%octopus.apiKey%"
+            args = "-SkipDuplicate"
+        }
+        powerShell {
+            name = "Extract release version from NuGet package"
+            formatStderrAsError = true
+            scriptMode = script {
+                content = """
+                    ${"$"}packages = Get-ChildItem -Path %teamcity.build.checkoutDir% -Filter *pre*.nupkg -Recurse
+                    ${"$"}packageName = ${"$"}packages[0].Name
+                    ${"$"}packageName -Match "buzz\.installer\.(.+)\.nupkg"
+                    ${"$"}packageVersion = ${"$"}Matches[1]
+                    Write-Host "##teamcity[setParameter name='octopus.release.version' value='${"$"}packageVersion']"
+                """.trimIndent()
+            }
+        }
+        powerShell {
+            name = "Create Release and Deploy to Integration"
+            formatStderrAsError = true
+            scriptMode = script {
+                content = """
+                    ${"$"}parameters = @(
+                        "create-release",
+                        "--server=%octopus.server%",
+                        "--project=%octopus.release.project%",
+                        "--defaultPackageVersion=%octopus.release.version%",
+                        "--releaseNumber=%octopus.release.version%",
+                        "--deployTo=%octopus.release.environment%"
+                        "--deploymenttimeout=%octopus.deploy.timeout%",
+                        "--apiKey=%octopus.apiKey%"
+                    )
+                    octo.exe @parameters
+
+                    exit ${"$"}LASTEXITCODE
+                """.trimIndent()
+            }
+        }
+    }
+
+})

--- a/.teamcity/Installer/buildTypes/PullRequestUIBuild.kt
+++ b/.teamcity/Installer/buildTypes/PullRequestUIBuild.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+package installer.buildTypes
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+
+object PullRequestInstallerBuild : BuildType ({
+    name = "Pull Request Build and Test"
+    templates(_self.templates.PullRequestTemplate)
+
+})

--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -26,6 +26,7 @@ object BuzzProject : Project({
     subProject(ui.UIProject)
     subProject(etl.ETLProject)
     subProject(api.APIProject)
+    subProject(installer.InstallerProject)
     subProject(angular.AngularProject)
     subProject(database.DatabaseProject)
 

--- a/EdFi.Buzz.Installer/build-package.ps1
+++ b/EdFi.Buzz.Installer/build-package.ps1
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+return 0;

--- a/EdFi.Buzz.Installer/edfi.buzz.nuspec
+++ b/EdFi.Buzz.Installer/edfi.buzz.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>edfi.buzz</id>
+    <version>$version$</version>
+    <title>Ed-Fi Buzz</title>
+    <authors>Ed-Fi Alliance, LLC and contributors</authors>
+    <projectUrl>https://github.com/Ed-Fi-Alliance-OSS/Buzz</projectUrl>
+    <copyright>Copyright © 2020, Ed-Fi Alliance, LLC and contributors.</copyright>
+    <license type="expression">Apache-2.0</license>
+    <summary>Buzz end-user website, API, ETL and database</summary>
+    <description>Buzz end-user website, API, ETL and database</description>
+  </metadata>
+  <files>
+    <file src=".\Windows\*" target="windows" />
+  </files>
+</package>

--- a/EdFi.Buzz.Installer/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Installer/eng/Windows/install.ps1
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+return 0;


### PR DESCRIPTION
This PR will provide a working teamcity build script and Nuget install script that both return exitcodes for success.

This should allow a developer to work TeamCity and a developer to create a locally runnable PowerShell Installer script in parallel.

NOTE: The new TeamCity build for this newly added Installer project will require a refresh of our Build project settings. Currently, it is not building. We should get a clean build.