### PR TITLE
[FIF-302] Fixes linting errors.

### DIFF
--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -108,7 +108,7 @@
     "@typescript-eslint/no-misused-new": "error",
     "@typescript-eslint/no-non-null-assertion": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-unused-expressions": "error",
-    "@typescript-eslint/no-unused-vars": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-unused-vars": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-use-before-define": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/quotes": [

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -109,7 +109,7 @@
     "@typescript-eslint/no-non-null-assertion": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-unused-vars": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
-    "@typescript-eslint/no-use-before-define": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-use-before-define": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/quotes": [
       "error",

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -196,7 +196,7 @@
     "no-unused-labels": "error",
     "no-use-before-define": [0],
     "no-useless-constructor": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
-    "max-classes-per-file": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "max-classes-per-file": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "no-var": "error",
     "prefer-const": "error",
     "radix": "error",

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -106,7 +106,7 @@
       }
     ],
     "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/no-non-null-assertion": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-non-null-assertion": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-unused-vars": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-use-before-define": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -98,7 +98,7 @@
     "@typescript-eslint/member-ordering": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-explicit-any": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-explicit-any": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-inferrable-types": [
       "error",
       {
@@ -182,7 +182,7 @@
       "error",
       "rxjs/Rx"
     ],
-    "no-return-assign": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "no-return-assign": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "no-shadow": [
       "error",
       {

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -95,7 +95,7 @@
         }
       }
     ],
-    "@typescript-eslint/member-ordering": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/member-ordering": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -136,7 +136,7 @@
     "guard-for-in": "error",
     "id-blacklist": "off",
     "id-match": "off",
-    "import/no-cycle": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "import/no-cycle": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "import/no-deprecated": "warn",
     "import/prefer-default-export": "off",
     "max-len": [
@@ -195,7 +195,7 @@
     "no-underscore-dangle": "off",
     "no-unused-labels": "error",
     "no-use-before-define": [0],
-    "no-useless-constructor": "warn", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "no-useless-constructor": "off", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "max-classes-per-file": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
     "no-var": "error",
     "prefer-const": "error",

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -121,6 +121,7 @@
     ],
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/unified-signatures": "error",
+    "@typescript-eslint/no-shadow": ["error"],
     "arrow-body-style": "error",
     "brace-style": [
       "error",
@@ -183,12 +184,7 @@
       "rxjs/Rx"
     ],
     "no-return-assign": "error",
-    "no-shadow": [
-      "error",
-      {
-        "hoist": "all"
-      }
-    ],
+    "no-shadow": "off",
     "no-throw-literal": "error",
     "no-trailing-spaces": "error",
     "no-undef-init": "error",

--- a/EdFi.Buzz.UI/.eslintrc.json
+++ b/EdFi.Buzz.UI/.eslintrc.json
@@ -95,10 +95,10 @@
         }
       }
     ],
-    "@typescript-eslint/member-ordering": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-explicit-any": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-inferrable-types": [
       "error",
       {
@@ -106,10 +106,10 @@
       }
     ],
     "@typescript-eslint/no-misused-new": "error",
-    "@typescript-eslint/no-non-null-assertion": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-unused-expressions": "error",
-    "@typescript-eslint/no-unused-vars": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
-    "@typescript-eslint/no-use-before-define": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/quotes": [
       "error",
@@ -136,7 +136,7 @@
     "guard-for-in": "error",
     "id-blacklist": "off",
     "id-match": "off",
-    "import/no-cycle": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "import/no-cycle": "error",
     "import/no-deprecated": "warn",
     "import/prefer-default-export": "off",
     "max-len": [
@@ -182,7 +182,7 @@
       "error",
       "rxjs/Rx"
     ],
-    "no-return-assign": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "no-return-assign": "error",
     "no-shadow": [
       "error",
       {
@@ -195,8 +195,8 @@
     "no-underscore-dangle": "off",
     "no-unused-labels": "error",
     "no-use-before-define": [0],
-    "no-useless-constructor": "off", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
-    "max-classes-per-file": "error", /* TODO REPLACE WITH "error" AND CORRECT LINT ERRORS */
+    "no-useless-constructor": "off",
+    "max-classes-per-file": "error",
     "no-var": "error",
     "prefer-const": "error",
     "radix": "error",

--- a/EdFi.Buzz.UI/src/App.tsx
+++ b/EdFi.Buzz.UI/src/App.tsx
@@ -8,7 +8,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Switch, Route, useHistory, Redirect } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
 
 import EnvironmentService from 'Services/EnvironmentService';
 import configureDI from 'DIContext';
@@ -22,7 +22,7 @@ import { StudentDetail } from 'Feature/StudentDetail';
 import { SurveyAnalytics } from 'Feature/SurveyAnalytics';
 import { UploadSurvey } from 'Feature/UploadSurvey';
 import { AdminSurvey } from 'Feature/AdminSurvey';
-import styled from 'styled-components';
+
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 import GlobalFonts from 'globalstyle';
@@ -78,16 +78,16 @@ export default function App(): JSX.Element {
           {/* A <Switch> looks through its children <Route>s and
             renders the first one that matches the current URL. */}
           <Content>
-          <Switch>
-            <Route exact path="/"> <StudentRoster api={api} /> </Route>
-            <Route path="/studentDetail/:studentKey"> <StudentDetail api={api} /> </Route>
-            <Route path="/surveyAnalytics"> <SurveyAnalytics api={api} /> </Route>
-            <Route path="/uploadSurvey/:surveyKey"> <UploadSurvey api={api} /> </Route>
-            <Route path="/uploadSurvey" > <UploadSurvey api={api}/> </Route>
-            {isAdminSurveyLoader
-              ? <Route path="/adminSurvey"> <AdminSurvey api={api} /> </Route>
-              : <Route><div>Need survey admin rights</div></Route>}
-          </Switch>
+            <Switch>
+              <Route exact path="/"> <StudentRoster api={api} /> </Route>
+              <Route path="/studentDetail/:studentKey"> <StudentDetail api={api} /> </Route>
+              <Route path="/surveyAnalytics"> <SurveyAnalytics api={api} /> </Route>
+              <Route path="/uploadSurvey/:surveyKey"> <UploadSurvey api={api} /> </Route>
+              <Route path="/uploadSurvey" > <UploadSurvey api={api}/> </Route>
+              {isAdminSurveyLoader
+                ? <Route path="/adminSurvey"> <AdminSurvey api={api} /> </Route>
+                : <Route><div>Need survey admin rights</div></Route>}
+            </Switch>
           </Content>
           <Footer height={FOOTER_HEIGHT}/>
         </div>

--- a/EdFi.Buzz.UI/src/Components/DataTable/dataTable.tsx
+++ b/EdFi.Buzz.UI/src/Components/DataTable/dataTable.tsx
@@ -1,4 +1,8 @@
-/* eslint-disable */
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
 import * as React from 'react';
 
 import styled from 'styled-components';
@@ -155,7 +159,7 @@ export interface ColumnOption {
   linkColumnIndex?: number;
 }
 
-function isColumnOption(column: any): column is ColumnOption {
+function isColumnOption(column: string | ColumnOption): column is ColumnOption {
   return column && typeof column === 'object' && 'label' in column;
 }
 
@@ -176,12 +180,12 @@ function convertToSortOption(sortBy: number | SortOption, desc?: boolean): SortO
 
 export interface FilterOptions {
   columnIndex: number;
-  filter: any;
+  filter: string;
 }
 
 export interface DataTableComponentProps {
   columns: string[] | ColumnOption[];
-  dataSet: any[][];
+  dataSet: string[][];
   defaultSort?: number | SortOption;
   alwaysSortLastByColumn?: number | SortOption;
   linkBaseURL?: string;
@@ -202,8 +206,25 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
           throw new Error('Action is not one of toggle, reset');
       }
     },
-    { Descending: false },
+    { Descending: false }
   );
+
+  function compareColumns(a: string[], b: string[], sortOption: SortOption) {
+    if (!sortOption) {
+      return 0;
+    }
+    let compare: number;
+    if (sortOption && a[sortOption.columnIndex] > b[sortOption.columnIndex]) {
+      compare = 1;
+    } else if (sortOption && a[sortOption.columnIndex] < b[sortOption.columnIndex]) {
+      compare = -1;
+    } else {
+      compare = 0;
+    }
+    return (
+      compare  * (sortOption.desc ? -1 : 1)
+    );
+  }
 
   const sortedDataset = props.dataSet
     .filter((row) => {
@@ -214,7 +235,7 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
     })
     .sort((a, b) => {
       const sortByCol = convertToSortOption(sortByColIndex, sortDirection.Descending);
-      const currentSortBy = sortByCol ? sortByCol : convertToSortOption(props.defaultSort);
+      const currentSortBy = sortByCol || convertToSortOption(props.defaultSort);
 
       const firstColSort = compareColumns(a, b, currentSortBy);
       if (firstColSort !== 0) {
@@ -224,19 +245,6 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
       const alwaysSortLastByColumn = convertToSortOption(props.alwaysSortLastByColumn);
       return compareColumns(a, b, alwaysSortLastByColumn);
     });
-
-  function compareColumns(a: any[], b: any[], sortOption: SortOption) {
-    if (!sortOption) {
-      return 0;
-    }
-    return (
-      (sortOption && a[sortOption.columnIndex] > b[sortOption.columnIndex]
-        ? 1
-        : sortOption && a[sortOption.columnIndex] < b[sortOption.columnIndex]
-        ? -1
-        : 0) * (sortOption.desc ? -1 : 1)
-    );
-  }
 
   function sortByEventHandler(colIndex: number) {
     if (sortByColIndex !== colIndex) {
@@ -255,6 +263,7 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
     >
       <thead>
         <tr>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
           {(props.columns as any).map((column, index) => {
             let label: string;
             if (typeof column === 'string') {

--- a/EdFi.Buzz.UI/src/Feature/Login/LoginADFS.tsx
+++ b/EdFi.Buzz.UI/src/Feature/Login/LoginADFS.tsx
@@ -5,9 +5,6 @@
  * See the LICENSE and NOTICES files in the project root for more information.
  */
 
-
-/* eslint @typescript-eslint/no-explicit-any: "off"*/
-
 import * as React from 'react';
 import { AuthenticationContext, AdalConfig } from 'react-adal';
 
@@ -39,6 +36,8 @@ export interface ADFSComponentProps {
   clientId: string;
   tenantId: string;
   className: string;
+
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   children: any;
   onLoggin?: (user: User) => void;
 }
@@ -49,6 +48,7 @@ export const ADFSButton: React.FunctionComponent<ADFSComponentProps> = (props: A
   const authContext = new AuthenticationContext(adalConfig);
   const token = authContext.getCachedToken(adalConfig.endpoints.api);
 
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   function tokenCallback(errorDesc: string | null, tokenId: string | null, error: any) {
     if (!tokenId) {
       return;

--- a/EdFi.Buzz.UI/src/Feature/Login/SocialButton.tsx
+++ b/EdFi.Buzz.UI/src/Feature/Login/SocialButton.tsx
@@ -5,12 +5,11 @@
  * See the LICENSE and NOTICES files in the project root for more information.
  */
 
-/* eslint @typescript-eslint/no-explicit-any: "off"*/
-
 import * as React from 'react';
 import SocialLogin from 'react-social-login';
 import Button from 'react-bootstrap/Button';
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 class SocialButton extends React.Component<any> {
 
   render() {

--- a/EdFi.Buzz.UI/src/Feature/Login/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/Login/index.tsx
@@ -5,8 +5,6 @@
  * See the LICENSE and NOTICES files in the project root for more information.
  */
 
-/* eslint @typescript-eslint/no-explicit-any: "off"*/
-
 import * as React from 'react';
 import { FunctionComponent } from 'react';
 import { Icon } from '@iconify/react';

--- a/EdFi.Buzz.UI/src/Feature/StudentDetail/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentDetail/index.tsx
@@ -248,7 +248,6 @@ export const StudentDetail: FunctionComponent<StudentDetailProps> = (props: Stud
 
   document.title = 'EdFi Buzz: Student Details';
 
-  // eslint-disable-next-line no-shadow
   enum ActiveTabEnum {
     Surveys = 'SURVEYS',
     Notes = 'NOTES',

--- a/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
@@ -58,7 +58,6 @@ export const StudentRoster: FunctionComponent<StudentRosterComponentProps> = (pr
   const [studentList, setStudentList] = useState([] as Student[]);
   const [selectedSectionKey, setSelectedSectionKey] = useState('');
 
-  // eslint-disable-next-line no-shadow
   enum ViewTypes {
     Card,
     Grid,

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as React from 'react';
 import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
@@ -41,7 +40,7 @@ const SurveyStyledCard = styled(StyledCard)`
 
 export const SurveyAnalytics: FunctionComponent<SurveyAnalyticsComponentProps> = (props: SurveyAnalyticsComponentProps) => {
   const {teacher} = props.api.authentication.currentUserValue;
-  const [sectionList, setSections] = useState(teacher.sections as Section[]);
+  const [sectionList] = useState(teacher.sections as Section[]);
   const [surveyMetadataList, setSurveyMetadataList] = useState([] as SurveyMetadata[]);
   const [selectedSectionKey, setSelectedSectionKey] = useState(null as string);
   const [showSearchResults, setShowSearchResults] = useState(false);
@@ -105,10 +104,11 @@ export const SurveyAnalytics: FunctionComponent<SurveyAnalyticsComponentProps> =
     surveyAnswersList: AllStudentAnswers[],
     surveyQuestionSummaryList: SurveyQuestionSummary[],
     questionFilter?: string
-  ): any[][] {
+  ): string[][] {
     if (!surveyAnswersList) {
       return [];
     }
+
     return surveyAnswersList.map((student) =>
       [student.studentschoolkey, student.studentname].concat(
         surveyQuestionSummaryList
@@ -124,7 +124,12 @@ export const SurveyAnalytics: FunctionComponent<SurveyAnalyticsComponentProps> =
         <TitleSpanContainer>Surveys</TitleSpanContainer>
         <TotalRecordsContainer>Total {surveyMetadataList.length}</TotalRecordsContainer>
       </HeadlineContainer>
-      <SearchInSections sectionList={sectionList} onSearch={onSearchHandle} defaultValue={selectedSectionKey} searchFilterPlaceholder={'Filter survey titles'} />
+      <SearchInSections
+        sectionList={sectionList}
+        onSearch={onSearchHandle}
+        defaultValue={selectedSectionKey}
+        searchFilterPlaceholder={'Filter survey titles'}
+      />
 
       {showSearchResults && (
         <div className='row'>

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
@@ -1,16 +1,21 @@
-/* eslint-disable */
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
 import * as React from 'react';
 import styled from 'styled-components';
 import SurveyQuestionSummary from 'Models/SurveyQuestionSummary';
 import { SurveyChart } from './surveyChart';
-import { DataTable } from '../../Components/DataTable/dataTable';
+import { DataTable , ColumnOption } from '../../Components/DataTable/dataTable';
 import ChevronDown from '../../assets/chevron-down.png';
 import ChevronUp from '../../assets/chevron-up.png';
 
+
 export interface ChartAndTableComponentProps {
   question: SurveyQuestionSummary;
-  columns: any[];
-  dataSet: any[];
+  columns: string[] | ColumnOption[];
+  dataSet: string[][];
   title?: string | React.ReactElement;
   afterSelectionChangedHandler?: (newSelection: string) => void;
 }
@@ -52,7 +57,7 @@ export const ChartAndTable: React.FunctionComponent<ChartAndTableComponentProps>
       afterSelectionChangedHandler={onAnswerSelectionChangedHandler} />
 
     <StyledSurveyArea onClick={() => setViewAnswersByStudent(!viewAnswersByStudent)} className={'view-answers-by-student'}>
-      <div>View Answers by Student<img src={!viewAnswersByStudent ? ChevronDown : ChevronUp} /></div>
+      <div>View Answers by Student<img src={!viewAnswersByStudent ? ChevronDown : ChevronUp} alt=""/></div>
     </StyledSurveyArea>
 
     {(viewAnswersByStudent && selectedQuestion) && <DataTable

--- a/EdFi.Buzz.UI/src/Feature/UploadSurvey/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/UploadSurvey/index.tsx
@@ -43,7 +43,6 @@ const StyledFileInputLabel = styled.label`
   border-width: 2px;
   color: var(--slate-gray);
   overflow: hidden;
-
   &::after {
     height: auto;
   }
@@ -57,25 +56,20 @@ const StyledTextParent = styled.div`
     justify-content: space-between;
     flex-direction: row;
   }
-
   @media (max-width: 768px) {
     display: block;
-
     & > .label {
       width: 100%
     }
   }
-
   margin: 0.5rem 0;
   overflow: hidden;
   border: ${(props) => props.theme.border};
   border-radius: 4px;
-
   :focus-within {
     outline: none !important;
     border-color: var(--denim) !important;
   }
-
   & > input {
     height: 100%;
     padding: 10px 10px;
@@ -84,30 +78,24 @@ const StyledTextParent = styled.div`
     box-sizing: border-box;
     min-width: 15rem;
     width: 100%;
-
     :focus {
       outline: none !important;
       outline-width: 0px;
     }
-
     ::placeholder,
     ::-webkit-input-placeholder {
       font-style: italic;
     }
-
     :-moz-placeholder {
       font-style: italic;
     }
-
     ::-moz-placeholder {
       font-style: italic;
     }
-
     :-ms-input-placeholder {
       font-style: italic;
     }
   }
-
   & > .label  {
     margin: 0;
     padding: 10px 10px;
@@ -117,7 +105,6 @@ const StyledTextParent = styled.div`
 
 
 const OutlineButton = styled.button`
-
 &.outline-button {
   width: 100%;
   justify-content: center;
@@ -131,7 +118,6 @@ const OutlineButton = styled.button`
   cursor: pointer;
   background-color: transparent;
 }
-
 &.outline-button:hover {
   color: white;
   background-color: var(--denim) !important;
@@ -177,7 +163,7 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
     );
   };
 
-  const createFileStatusMessage = React.useCallback ((fileStatus: FileStatus): FileStatus => {
+  const createFileStatusMessage = (fileStatus: FileStatus): FileStatus => {
     if (!fileStatus || !fileStatus.fileName) {
       return fileStatusMessage;
     }
@@ -202,15 +188,15 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
         }
       );
     return newFileStatus;
-  }, [fileStatusMessage]);
+  };
 
-  const saveLastUploadedSurvey = React.useCallback((message: FileStatus) => {
+  const saveLastUploadedSurvey = (message: FileStatus) => {
     if (message && message.fileName && message.fileName.length > 0) {
       storage.setItem('lastUploadedSurvey', JSON.stringify(message));
     }
-  }, [storage]);
+  };
 
-  const GetJobStatus = React.useCallback (async (staffkey: number, jobkey: string, currentFileStatus: FileStatus) => {
+  const GetJobStatus = async (staffkey: number, jobkey: string, currentFileStatus: FileStatus) => {
     const values = await api.survey.getSurveyStatus(staffkey, jobkey);
     const value = values && values.length > 0 ? values[0] : null;
     const statusMessage = currentFileStatus || fileStatusMessage;
@@ -235,9 +221,9 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
         () => GetJobStatus(staffkey, jobkey, statusMessage),
         SURVEY_STATUS_QUERY_TIME_IN_MS));
     }
-  }, [api.survey, createFileStatusMessage, fileStatusMessage, saveLastUploadedSurvey]);
+  };
 
-  const loadLastUploadedSurvey = React.useCallback(() => {
+  const loadLastUploadedSurvey = () => {
     const message = JSON.parse(storage.getItem('lastUploadedSurvey'));
     if (message && message.serverJobStatus && !api.survey.JOB_STATUS_FINISH_IDS.includes(message.serverJobStatus.jobstatuskey)) {
       setFileStatusMessage(createFileStatusMessage(message));
@@ -247,7 +233,7 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
       return undefined;
     }
     return message;
-  }, [GetJobStatus, api.survey.JOB_STATUS_FINISH_IDS, createFileStatusMessage, storage]);
+  };
 
   function SurveyStatusAreEqual(Object1: SurveyStatus, Object2: SurveyStatus): boolean {
     return Object1?.surveykey === Object2?.surveykey &&
@@ -275,7 +261,9 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
 
   useEffect(() => {
     loadLastUploadedSurvey();
-  }, [loadLastUploadedSurvey]);
+
+  /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, []);
 
   useEffect(() => {
     const jobStatusKey = fileStatusMessage?.serverJobStatus?.jobstatuskey;
@@ -527,4 +515,3 @@ export const UploadSurvey: FunctionComponent<UploadSurveyProps> = (props: Upload
   );
 
 };
-

--- a/EdFi.Buzz.UI/src/Models/ResultSummaryObj.ts
+++ b/EdFi.Buzz.UI/src/Models/ResultSummaryObj.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import StudentSurveySummaryAnswers from './StudentSurveySummaryAnswers';
+import StudentSurveySummaryAnswersProcess from './StudentSurveySummaryAnswersProcess';
+
+export default class ResultSummaryObj {
+  survey: StudentSurveySummaryAnswers;
+
+  process?: StudentSurveySummaryAnswersProcess;
+}

--- a/EdFi.Buzz.UI/src/Models/StudentSurveySummaryAnswersProcess.ts
+++ b/EdFi.Buzz.UI/src/Models/StudentSurveySummaryAnswersProcess.ts
@@ -3,22 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-export default class StudentSurveySummaryAnswers {
-  sectionkey?: string;
+import StudentSurveySummaryAnswers from './StudentSurveySummaryAnswers';
 
-  surveykey?: number;
+export default class StudentSurveySummaryAnswersProcess extends StudentSurveySummaryAnswers {
+  load?: number;
 
-  title?: string;
+  alreadyLoaded?: number;
 
-  surveyquestionkey?: number;
-
-  question?: string;
-
-  questions?: number;
-
-  studentschoolkey?: string;
-
-  studentname?: string;
-
-  answer?: string;
+  rejected?: number;
 }

--- a/EdFi.Buzz.UI/src/Models/Survey.ts
+++ b/EdFi.Buzz.UI/src/Models/Survey.ts
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 export default class Survey {
-/* eslint max-classes-per-file: "off"*/
 /* eslint @typescript-eslint/no-explicit-any: "off"*/
 
   surveykey?: number;

--- a/EdFi.Buzz.UI/src/Models/Survey.ts
+++ b/EdFi.Buzz.UI/src/Models/Survey.ts
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 export default class Survey {
-/* eslint @typescript-eslint/no-explicit-any: "off"*/
 
   surveykey?: number;
 

--- a/EdFi.Buzz.UI/src/Models/SurveyStatus.ts
+++ b/EdFi.Buzz.UI/src/Models/SurveyStatus.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 import JobStatus from './JobStatus';
+import ResultSummaryObj from './ResultSummaryObj';
 
 export default class SurveyStatus {
   surveystatuskey: number;
@@ -17,8 +18,7 @@ export default class SurveyStatus {
 
   resultsummary: string;
 
-  // eslint-disable-next-line
-  resultSummaryObj: any;
+  resultSummaryObj: ResultSummaryObj;
 
   jobstatus: JobStatus;
 }

--- a/EdFi.Buzz.UI/src/Services/ApiService.ts
+++ b/EdFi.Buzz.UI/src/Services/ApiService.ts
@@ -13,7 +13,6 @@ import SurveyService from './SurveyService';
 
 export default class ApiService {
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(
     public authentication: AuthenticationService,
     public section: SectionApiService,

--- a/EdFi.Buzz.UI/src/Services/AuthenticationService.ts
+++ b/EdFi.Buzz.UI/src/Services/AuthenticationService.ts
@@ -16,7 +16,6 @@ export default class AuthenticationService {
 
   private currentUserSubject: BehaviorSubject<User>;
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(
     private teacherService: TeacherApiService,
     private apolloClient: ApolloClient<InMemoryCache>

--- a/EdFi.Buzz.UI/src/Services/GraphQL/SectionQueries.ts
+++ b/EdFi.Buzz.UI/src/Services/GraphQL/SectionQueries.ts
@@ -15,5 +15,5 @@ query($staffkey: ID!) {
   }
 }
 `;
-// eslint-disable-next-line
+
 export { getSectionsByStaff };

--- a/EdFi.Buzz.UI/src/Services/SectionService.ts
+++ b/EdFi.Buzz.UI/src/Services/SectionService.ts
@@ -10,11 +10,8 @@ import { getSectionsByStaff } from './GraphQL/SectionQueries';
 import AuthenticationService from './AuthenticationService';
 
 export default class SectionApiService {
-  controllerName = 'section';
-
   sections: Section[];
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(
     private authenticationService: AuthenticationService,
     private apolloClient: ApolloClient<InMemoryCache>

--- a/EdFi.Buzz.UI/src/Services/StudentNotesService.ts
+++ b/EdFi.Buzz.UI/src/Services/StudentNotesService.ts
@@ -8,7 +8,6 @@ import { StudentNote } from '../Models';
 
 export default class StudentNotesApiService {
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(private apolloClient: ApolloClient<InMemoryCache>) { }
 
   public addStudentNote = (staffKey: number, studentSchoolKey: string, note: string): Promise<StudentNote> => {

--- a/EdFi.Buzz.UI/src/Services/StudentService.ts
+++ b/EdFi.Buzz.UI/src/Services/StudentService.ts
@@ -11,7 +11,6 @@ import AuthenticationService from './AuthenticationService';
 export default class StudentApiService {
   students: Student[];
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(private auth: AuthenticationService, private apolloClient: ApolloClient<InMemoryCache>) { }
 
   public get = async(section?: string, name?: string): Promise<Student[]> => {

--- a/EdFi.Buzz.UI/src/Services/SurveyAnalyticsService.ts
+++ b/EdFi.Buzz.UI/src/Services/SurveyAnalyticsService.ts
@@ -14,7 +14,6 @@ import AllStudentAnswers from '../Models/AllStudentAnswers';
 
 export default class SurveyAnalyticsApiService{
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(private studentService: StudentApiService,
     private authenticationService: AuthenticationService,
     private apolloClient: ApolloClient<InMemoryCache>) {

--- a/EdFi.Buzz.UI/src/Services/SurveyAnalyticsService.ts
+++ b/EdFi.Buzz.UI/src/Services/SurveyAnalyticsService.ts
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 import { ApolloClient, InMemoryCache } from '@apollo/client';
 import Teacher from 'Models/Teacher';
+import { SurveyQuestionAnswer } from 'Models';
 import StudentApiService from './StudentService';
 import { getSurveySummaryBySectionKey, getSurveyQuestionsSummary } from './GraphQL/SurveyQueries';
 import AuthenticationService from './AuthenticationService';
@@ -132,8 +133,8 @@ export default class SurveyAnalyticsApiService{
   }]
   */
   public getSurveyQuestionSummaryList = async(surveyKey: number, sectionKey: string): Promise<SurveyQuestionSummary[]> => {
-    // eslint-disable-next-line
-    const calculateTopAnswers = (answers: any[]) => {
+
+    const calculateTopAnswers = (answers: SurveyQuestionAnswer[]) => {
       const countAnswers = answers
         .reduce((aaccParam, acur) => {
           const aacc = aaccParam;
@@ -142,8 +143,7 @@ export default class SurveyAnalyticsApiService{
         }, {});
 
       return Object.keys(countAnswers)
-      // eslint-disable-next-line
-        .map((cur, idx, arr) => ({
+        .map((cur) => ({
           label: cur,
           count: countAnswers[cur]
         }));
@@ -164,8 +164,7 @@ export default class SurveyAnalyticsApiService{
     }
     const surveysummary = data.surveysummary[0];
     const questions = surveysummary.questions
-    // eslint-disable-next-line
-      .map((qcur, qidx, qarr) => ({
+      .map((qcur) => ({
         surveykey: data.surveysummary[0].surveykey,
         surveyquestionkey: qcur.surveyquestionkey,
         question: qcur.question,

--- a/EdFi.Buzz.UI/src/Services/SurveyService.ts
+++ b/EdFi.Buzz.UI/src/Services/SurveyService.ts
@@ -15,7 +15,6 @@ export default class SurveyService{
 
   private apollo: ApolloClient<InMemoryCache>;
 
-  /* eslint no-useless-constructor: "off"*/
   constructor(private env: EnvironmentService, private apolloClient: ApolloClient<InMemoryCache>) {
     this.SURVEY_MAX_FILE_SIZE_BYTES = Number(process.env.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES);
     this.JOB_STATUS_FINISH_IDS = this.env.environment.JOB_STATUS_FINISH_IDS;

--- a/EdFi.Buzz.UI/src/Services/TeacherService.ts
+++ b/EdFi.Buzz.UI/src/Services/TeacherService.ts
@@ -8,9 +8,6 @@ import Teacher from 'Models/Teacher';
 import { getStaffNameById, getStaffByEMail } from './GraphQL/StaffQueries';
 
 export default class TeacherApiService {
-  controllerName = 'teacher';
-
-  /* eslint no-useless-constructor: "off"*/
   constructor(private apolloClient: ApolloClient<InMemoryCache>) {  }
 
   getTeacher = async(): Promise<Teacher> => {


### PR DESCRIPTION
I removed all the TODOs in the root linting configuration.
I had to keep some exception in specific cases, specially (but not exclusively) the any type.
Places where I had to keep the any type: datatable, loginADFS (2 lines), SocialButton. I used the eslint-disable-next-line option instead of disabling the rule for an entire file.
### A couple other cases:
1. **StudentDetailSurvey**
```
/* eslint no-return-assign: "off"*/
    survey.answers.map((a, index) => (
        <StudentDetailSurveyAnswerRow key={index} idx={i += 1} answer={a} />
    ))}
```
For some reason eslint does not like the `i+=1`. Not sure why, because based on the documentation this is the right way to increment the value.

2. **UploadSurvey/index**
```
useEffect(() => {
    loadLastUploadedSurvey();
  /* eslint-disable-next-line react-hooks/exhaustive-deps */
  }, []);
```
Ideally, we would define the **loadLastUploadedSurvey** method as a dependency of the **useEffect**. The problem is that when we do that, the component starts to render in an infinite loop. I couldn’t figure out how to fix this. We may consider opening a bug ticket to keep track of it and revisit it in the future. For now, the upload page component works fine the way it is. 
