### PR TITLE
[FIF-164] Catch when tokens expire

### DIFF
--- a/EdFi.Buzz.UI/src/DIContext.ts
+++ b/EdFi.Buzz.UI/src/DIContext.ts
@@ -46,11 +46,43 @@ function createApolloClient() {
     };
   });
 
+
+/*
+Change the implemention of the client to Apollo-boost will avoid the flash for 1 second showing the error page
+but will require to update some API calls from UI to hanlde asyn errors:
+
+new ApolloClient({
+  uri: `${window.location.origin}/api`,
+  cache: new InMemoryCache(),
+  onError({ graphQLErrors, networkError }) {
+    if(graphQLErrors)
+      graphQLErrors.forEach(error => notification.error({
+        message: 'Error',
+        description: error.message
+      }))
+    if(networkError)
+      notification.error({
+        message: 'Network Error',
+        description: `A network error has occurred. Please check out your connection.`
+      })
+  },
+  request(operation) {
+    const currentUser = readStore('currentUser')
+    currentUser && operation.setContext({
+      headers: { authorization: currentUser.token }
+    })
+  }
+})
+
+
+
+*/
+
   const errorLink = onError(
     ({ response, graphQLErrors, networkError, operation, forward }) => {
       if(graphQLErrors[0].extensions.exception.status === 401){
         window.location.replace('/login');
-        response.errors = undefined;
+        response.errors = null;
       }
     }
   );

--- a/EdFi.Buzz.UI/src/DIContext.ts
+++ b/EdFi.Buzz.UI/src/DIContext.ts
@@ -4,8 +4,11 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 
-import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
+import { ApolloClient, createHttpLink, InMemoryCache, ApolloLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+
+
 
 import DIContainer, { object, get } from 'rsdi';
 
@@ -43,8 +46,18 @@ function createApolloClient() {
     };
   });
 
+  const errorLink = onError(
+    ({ response, graphQLErrors, networkError, operation, forward }) => {
+      if(graphQLErrors[0].extensions.exception.status === 401){
+        window.location.replace('/login');
+        response.errors = undefined;
+      }
+    }
+  );
+
   return new ApolloClient({
-    link: authLink.concat(httpLink),
+    link: ApolloLink.from([errorLink, authLink, httpLink]),
+    //link: authLink.concat(httpLink),
     cache: new InMemoryCache()
   });
 


### PR DESCRIPTION
Adding validation to have handled when JWT has expired and redirect to the login page. 

Redirecting the user to login is working but is missing to update Apollo client to Apollo boost to avoid showing the error page for some seconds.

