### PR TITLE
[FIF-324] Adds Upload Survey option to the top-right drop down menu.

### DIFF
--- a/EdFi.Buzz.UI/src/App.tsx
+++ b/EdFi.Buzz.UI/src/App.tsx
@@ -43,6 +43,8 @@ export default function App(): JSX.Element {
   const [isLoggedIn, setIsLoggedIn] = useState(api.authentication.currentUserValue != null);
   const [isAdminSurveyLoader, setIsAdminSurveyLoader] =
     useState(api.authentication.currentUserValue?.teacher?.isadminsurveyloader === true);
+  const [isTeacherSurveyLoader, setIsTeacherSurveyLoader] =
+    useState(api.authentication.currentUserValue?.teacher?.isteachersurveyloader === true);
   const Content = styled.div`
     @media(max-width:768px){
       padding-top: ${HEADER_HEIGHT}px;
@@ -57,6 +59,7 @@ export default function App(): JSX.Element {
     const suscription = api.authentication.currentUser.subscribe((cu) => {
       setIsLoggedIn(cu && cu.teacher != null);
       setIsAdminSurveyLoader(cu?.teacher?.isadminsurveyloader === true);
+      setIsTeacherSurveyLoader(cu?.teacher?.isteachersurveyloader === true);
     });
     return () => suscription.unsubscribe();
   });
@@ -74,7 +77,11 @@ export default function App(): JSX.Element {
       </Route>
       {!isLoggedIn ? <Redirect to="/login" /> : <Route path="/">
         <div>
-          <Header api={api} isAdminSurveyLoader={isAdminSurveyLoader} navigate={(url) => history.push(url)} height={HEADER_HEIGHT} />
+          <Header api={api}
+            isAdminSurveyLoader={isAdminSurveyLoader}
+            isTeacherSurveyLoader={isTeacherSurveyLoader}
+            navigate={(url) => history.push(url)}
+            height={HEADER_HEIGHT} />
           {/* A <Switch> looks through its children <Route>s and
             renders the first one that matches the current URL. */}
           <Content>
@@ -83,10 +90,13 @@ export default function App(): JSX.Element {
               <Route path="/studentDetail/:studentKey"> <StudentDetail api={api} /> </Route>
               <Route path="/surveyAnalytics"> <SurveyAnalytics api={api} /> </Route>
               <Route path="/uploadSurvey/:surveyKey"> <UploadSurvey api={api} /> </Route>
-              <Route path="/uploadSurvey" > <UploadSurvey api={api}/> </Route>
+              {isAdminSurveyLoader || isTeacherSurveyLoader
+                ? <Route path="/uploadSurvey"> <UploadSurvey api={api} /> </Route>
+                : <Route><div>Need upload survey rights</div></Route>}
               {isAdminSurveyLoader
                 ? <Route path="/adminSurvey"> <AdminSurvey api={api} /> </Route>
                 : <Route><div>Need survey admin rights</div></Route>}
+
             </Switch>
           </Content>
           <Footer height={FOOTER_HEIGHT}/>

--- a/EdFi.Buzz.UI/src/Components/Header/index.tsx
+++ b/EdFi.Buzz.UI/src/Components/Header/index.tsx
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 import Icon from '@iconify/react';
 import mdUnlock from '@iconify-icons/ion/md-unlock';
 import mdBuild from '@iconify-icons/ion/md-build';
+import mdUpload from '@iconify-icons/ion/md-cloud-upload';
 
 interface CustomLikComponentProps {
   children: ReactFragment;
@@ -73,6 +74,7 @@ export interface HeaderComponentProps {
   title?: string;
   api: ApiService;
   isAdminSurveyLoader?: boolean;
+  isTeacherSurveyLoader?: boolean;
   navigate: (url: string) => void;
   height: number;
 }
@@ -82,7 +84,7 @@ export const Header: FunctionComponent<HeaderComponentProps> = (
 ) => {
   const [menuActive, setMenuActive] = useState(false);
   const { teacher } = props.api.authentication.currentUserValue;
-  const { isAdminSurveyLoader } = props;
+  const { isAdminSurveyLoader, isTeacherSurveyLoader } = props;
   const { height } = props;
   const LinkButton = styled.button`
   text-transform: uppercase;
@@ -274,8 +276,14 @@ export const Header: FunctionComponent<HeaderComponentProps> = (
                     {isAdminSurveyLoader
                       ? <li>
                         <Link to="/adminSurvey">
-
                           <LinkButton><Icon icon={mdBuild}></Icon>&nbsp;Admin Survey</LinkButton>
+                        </Link>
+                      </li>
+                      : null}
+                    {isAdminSurveyLoader || isTeacherSurveyLoader
+                      ? <li>
+                        <Link to="/uploadSurvey">
+                          <LinkButton><Icon icon={mdUpload}></Icon>&nbsp;Upload Survey</LinkButton>
                         </Link>
                       </li>
                       : null}

--- a/EdFi.Buzz.UI/src/__mocks__/@iconify-icons/ion/md-cloud-upload.js
+++ b/EdFi.Buzz.UI/src/__mocks__/@iconify-icons/ion/md-cloud-upload.js
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+export default 'mdUpload';


### PR DESCRIPTION
### Solution
The Upload Survey options was not added to the drop down menu. The solution included adding the menu option with the validations to show it when the **isAdminSurveyLoader** flag or the **isTeacherSurveyLoader** flag is on. 

### Testing. 
Log in and log out to the app while you modify the staff.isadminsurveyloader and staff.isteachersurveyloader values in the database. See how the option menu to Upload Survey is shown or not. The menu option should be shown when one of these 2 values is on. 

Additionally try to access the Upload Survey page using the address bar. 