### PR TITLE
[FIF-271] Adds validation to the installer so the user is forced to provide goo…

### DIFF
--- a/EdFi.Buzz.Installer/eng/Windows/Application/appinstallValidations.psm1
+++ b/EdFi.Buzz.Installer/eng/Windows/Application/appinstallValidations.psm1
@@ -6,7 +6,7 @@
 #Requires -version 5
 #Requires -RunAsAdministrator
 
-function Authentication-Configuration-Valid {
+function Test-AuthConfiguration {
     param (
         [string] $idProvider,
         [string] $clientSecret,
@@ -26,7 +26,7 @@ function Authentication-Configuration-Valid {
 }
 
 $functions = @(
-    "Authentication-Configuration-Valid"
+    "Test-AuthConfiguration"
 )
 
 Export-ModuleMember $functions

--- a/EdFi.Buzz.Installer/eng/Windows/Application/appinstallValidations.psm1
+++ b/EdFi.Buzz.Installer/eng/Windows/Application/appinstallValidations.psm1
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -version 5
+#Requires -RunAsAdministrator
+
+function Authentication-Configuration-Valid {
+    param (
+        [string] $idProvider,
+        [string] $clientSecret,
+        [string] $googleClientId,
+        [string] $adfsClientId,
+        [string] $adfsTenantId
+    )
+
+    if ("google" -eq $idProvider -and $googleClientId -ne $null -and $googleClientId.Trim() -ne "" -and $clientSecret -ne $null -and $clientSecret.Trim() -ne "") {
+        return $true;
+    }
+    elseif ("adfs" -eq $idProvider -and $adfsClientId -ne $null -and $adfsClientId.Trim() -ne "" -and $adfsTenantId -ne $null -and $adfsTenantId.Trim() -ne "") {
+        return $true;
+    }
+
+    return $false;
+}
+
+$functions = @(
+    "Authentication-Configuration-Valid"
+)
+
+Export-ModuleMember $functions

--- a/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
+++ b/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
@@ -251,7 +251,7 @@ function Get-WebStatus {
     return $status
 }
 
-function Check-BuzzServices {
+function Test-BuzzServices {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
@@ -288,7 +288,7 @@ $functions = @(
     "Install-DatabaseApp",
     "Install-EtlApp",
     "Install-UiApp",
-    "Check-BuzzServices"
+    "Test-BuzzServices"
 )
 
 Export-ModuleMember $functions

--- a/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
+++ b/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
@@ -160,6 +160,7 @@ function Install-UiApp {
         "InstallPath"     = Join-Path $configuration.InstallPath "UI";
         "port"            = $configuration.ui.port;
         "graphQlEndpoint" = $configuration.api.url;
+        "idProvider"      = $configuration.idProvider;
         "googleClientId"  = $configuration.googleClientId;
         "adfsClientId"    = $configuration.adfsClientId;
         "adfsTenantId"    = $configuration.adfsTenantId;

--- a/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
+++ b/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
@@ -8,8 +8,8 @@
     "installUi": true,
     "installApi": true,
     "idProvider": "google",
-    "clientSecret": "*******",
-    "googleClientId": "********",
+    "clientSecret": null,
+    "googleClientId": null,
     "adfsClientId": null,
     "adfsTenantId": null,
     "postgresDatabase": {

--- a/EdFi.Buzz.Installer/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Installer/eng/Windows/install.ps1
@@ -37,6 +37,7 @@ param (
 Import-Module "$PSScriptRoot/configHelper.psm1" -Force
 Import-Module "$PSScriptRoot/init.psm1" -Force
 Import-Module "$PSScriptRoot/Application/appinstalls.psm1" -Force
+Import-Module "$PSScriptRoot/Application/appinstallValidations.psm1" -Force
 
 # Confirm required parameters to install
 # Repo location should be configuration with overrides
@@ -55,6 +56,12 @@ $packagesPath = $conf.packagesPath
 $toolsPath = $conf.toolsPath
 
 try {
+    # Validating Auth configuration
+    if (-not (Authentication-Configuration-Valid -idProvider $conf.idProvider -clientSecret $conf.clientSecret -googleClientId $conf.googleClientId -adfsClientId $conf.adfsClientId -adfsTenantId $conf.adfsTenantId)) {
+        Write-Error "Buzz authentication configuration has not been provided properly. Please either provide Google's client identifier and sercret, or ADFS's client and tenant identifiers."
+        exit -1;
+    }
+
     Initialize-Installer -toolsPath $toolsPath  -packagesPath $packagesPath
 
     $params = @{

--- a/EdFi.Buzz.Installer/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Installer/eng/Windows/install.ps1
@@ -57,7 +57,7 @@ $toolsPath = $conf.toolsPath
 
 try {
     # Validating Auth configuration
-    if (-not (Authentication-Configuration-Valid -idProvider $conf.idProvider -clientSecret $conf.clientSecret -googleClientId $conf.googleClientId -adfsClientId $conf.adfsClientId -adfsTenantId $conf.adfsTenantId)) {
+    if (-not (Test-AuthConfiguration -idProvider $conf.idProvider -clientSecret $conf.clientSecret -googleClientId $conf.googleClientId -adfsClientId $conf.adfsClientId -adfsTenantId $conf.adfsTenantId)) {
         Write-Error "Buzz authentication configuration has not been provided properly. Please either provide Google's client identifier and sercret, or ADFS's client and tenant identifiers."
         exit -1;
     }
@@ -75,7 +75,7 @@ try {
     Install-EtlApp @params
     Install-UiApp @params
 
-    Check-BuzzServices $script:conf
+    Test-BuzzServices $script:conf
     Write-Host "Ed-Fi Buzz installation complete."
 }
 catch {

--- a/EdFi.Buzz.UI/eng/windows/install.ps1
+++ b/EdFi.Buzz.UI/eng/windows/install.ps1
@@ -23,6 +23,8 @@ param(
   [Parameter(Mandatory = $true)]
   [string] $graphQlEndpoint,
 
+  [Parameter(Mandatory = $true)]
+  [string] $idProvider,
   [string] $googleClientId,
   [string] $adfsClientId,
   [string] $adfsTenantId,
@@ -44,19 +46,16 @@ Initialize-Installer -toolsPath $toolsPath  -packagesPath $packagesPath
 
 Write-Host "Begin Ed-Fi Buzz $($script:app) installation..." -ForegroundColor Yellow
 
-if (![string]::IsNullOrEmpty($googleClientId)) {
-  $adfsClient = ""
-  $adfsTenantId = ""
-}
+$envFile = ""
 
-# Use Google unless ADFS is populated
-$envFile = @"
+if ("google" -eq $idProvider) {
+  $envFile = @"
 /*
- * SPDX-License-Identifier: Apache-2.0
- * Licensed to the Ed-Fi Alliance under one or more agreements.
- * The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
- * See the LICENSE and NOTICES files in the project root for more information.
- */
+* SPDX-License-Identifier: Apache-2.0
+* Licensed to the Ed-Fi Alliance under one or more agreements.
+* The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+* See the LICENSE and NOTICES files in the project root for more information.
+*/
 PORT=$port
 REACT_APP_GQL_ENDPOINT=$graphQlEndpoint
 REACT_APP_GOOGLE_CLIENT_ID=$googleClientId
@@ -65,8 +64,8 @@ REACT_APP_ADFS_TENANT_ID=
 REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES=1048576
 REACT_APP_JOB_STATUS_FINISH_IDS=[3]
 "@
-
-if ($adfsClientId.Length -gt 1) {
+}
+else {
   $envFile = @"
 /*
 * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
…gle or adfs authentication configuration values.

### Testing
Before you execute \EdFi.Buzz.Installer\eng\Windows\install.ps1, change the Google and ADFS values. For example: 
1. Add the googleClientId but keep the clientSecret null or empty. Or the other way around.
2. Change the idProvider value to adfs and then add a value for adfsClientId, but keep the adfsTenantId null, or the other way around. 
3. Etc.
After all the failure scenarios you can think of are tested. Make sure you test a success scenario with Google and then with ADFS.
