### PR TITLE
[FIF-326] Removes hardcoded GraphQL endpoint in the apollo client creation func…

### DIFF
--- a/EdFi.Buzz.UI/src/DIContext.ts
+++ b/EdFi.Buzz.UI/src/DIContext.ts
@@ -19,16 +19,14 @@ import SurveyAnalyticsApiService from 'Services/SurveyAnalyticsService';
 import SurveyService from 'Services/SurveyService';
 import TeacherApiService from 'Services/TeacherService';
 
-
-
-function createApolloClient() {
+function createApolloClient(container: DIContainer) {
+  const env: EnvironmentService = container.get('EnvironmentService');
   const httpLink = createHttpLink({
-    uri: 'http://localhost:3000/graphql',
+    uri: env.environment.GQL_ENDPOINT,
     fetchOptions: {
       mode: 'cors'
     }
   });
-
 
   const authLink = setContext((_, { headers }) => {
     // get the authentication token from local storage if it exists
@@ -47,15 +45,15 @@ function createApolloClient() {
     link: authLink.concat(httpLink),
     cache: new InMemoryCache()
   });
-
 }
-
 
 export default function configureDI(): DIContainer {
   const container = new DIContainer();
   container.addDefinitions({
-    'EnvironmentService': object(EnvironmentService).construct(),
-    'ApolloClient': createApolloClient(),
+    'EnvironmentService': object(EnvironmentService).construct()
+  })
+  container.addDefinitions({
+    'ApolloClient': createApolloClient(container),
     'ApiService': object(ApiService).construct(
       get('AuthenticationService'),
       get('SectionApiService'),
@@ -92,8 +90,6 @@ export default function configureDI(): DIContainer {
       get('EnvironmentService'),
       get('ApolloClient')
     )
-
-
   });
   return container;
 }


### PR DESCRIPTION
…tion.

### Testing 
For testing purposes basically we need to execute the API and the UI and make sure the calls to GraghQL are working fine. 

Additionally, you can change the BUZZ_API_HTTP_PORT value in the env file of the API to something different to 3000. And then do the same in the UI, (the value here is REACT_APP_GQL_ENDPOINT). Then execute the 2 apps again and make sure the call to the GraphQL still work fine.
