### PR TITLE
[FIF-291] Update installer

### DIFF
--- a/.teamcity/Installer/buildTypes/DeployInstaller.kt
+++ b/.teamcity/Installer/buildTypes/DeployInstaller.kt
@@ -50,7 +50,7 @@ object DeployInstallerBuild : BuildType ({
                 content = """
                     ${"$"}packages = Get-ChildItem -Path %teamcity.build.checkoutDir% -Filter *pre*.nupkg -Recurse
                     ${"$"}packageName = ${"$"}packages[0].Name
-                    ${"$"}packageName -Match "buzz\.installer\.(.+)\.nupkg"
+                    ${"$"}packageName -Match "edfi.buzz\.(.+)\.nupkg"
                     ${"$"}packageVersion = ${"$"}Matches[1]
                     Write-Host "##teamcity[setParameter name='octopus.release.version' value='${"$"}packageVersion']"
                 """.trimIndent()

--- a/EdFi.Buzz.Installer/eng/edfi.buzz.nuspec
+++ b/EdFi.Buzz.Installer/eng/edfi.buzz.nuspec
@@ -11,7 +11,11 @@
         <summary>Buzz end-user website, API, ETL and database</summary>
         <description>Buzz end-user website, API, ETL and database</description>
         <dependencies>
-            <dependency id="EdFi.Installer.AppCommon" version="1.0.3" />
+            <dependency id="EdFi.Installer.AppCommon" version="[1.0.3]" />
+            <dependency id="edfi.buzz.database" version="$version$" />
+            <dependency id="edfi.buzz.api" version="$version$" />
+            <dependency id="edfi.buzz.etl" version="$version$" />
+            <dependency id="edfi.buzz.ui" version="$version$" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
This updates the edfi.buzz installer NuGet packages after running the Octopus Deploy that uncovered some missing elements.

Currently, the package needs to download the Buzz apps as Nuget dependencies, and the DeployInstaller TeamCity build template was referring to the wrong name.

TeamCity was looking for buzz.installer*.nupkg and not finding it because we create edfi.buzz.*.nupkg...
![image](https://user-images.githubusercontent.com/63315476/95637056-63a2a200-0a56-11eb-88cd-5c8851689a26.png)

This adds Buzz apps dependencies with versions that match the Installer. Currently, we are version 0.1.0, so the versions will match this version. And changes the name of the package that installer looks for in the TeamCity deploy project.

![image](https://user-images.githubusercontent.com/63315476/95637099-81700700-0a56-11eb-83a2-0470d0a0aa2e.png)


