### PR TITLE
[FIF-329] Update jquery with a package resolution

### DIFF
--- a/EdFi.Buzz.UI/package.json
+++ b/EdFi.Buzz.UI/package.json
@@ -71,6 +71,9 @@
     "synp": "1.7.0",
     "typescript": "^4.0.2"
   },
+  "resolutions": {
+    "jquery": ">=3.5.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "start-prod": "yarn build && serve -s build",


### PR DESCRIPTION
Dependabot left us a security message to upgrade jquery. 
~~I did that and discovered synp also had a low-risk fix needed.~~

~~Both are updated...~~
synp came up as a low level fix in the package audit but updating that causes TeamCity build errors. FIF-313 already should address this issue. I will update it to make sure it is included.