### PR TITLE
[FIF-346] Removes odsDataStandard setting from the installer configuration file…

### DIFF
--- a/EdFi.Buzz.Installer/eng/README.md
+++ b/EdFi.Buzz.Installer/eng/README.md
@@ -84,7 +84,6 @@ Options to configure the ETL to load from the database or file to the postgres d
 
 - **version:** The NuGet version to download. Blank gets latest.
 - **datasourceFormat:** If the data source corresponds to the Analytics Middle Tier (amt) or direct views of the ODS tables. Allowed values: amt, ods.
-- **odsDataStandard:** Database standard to use, if it is Data Standard 2 or 3.x. Allowed values: ds2, ds3.
 
 #### api
 

--- a/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
+++ b/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
@@ -37,7 +37,6 @@
     "etl" : {
         "version": null,
         "datasourceFormat": "amt",
-        "odsDataStandard": "ds3",
         "max": 20,
         "idleTimeoutMilliseconds": 5000,
         "connectionTimeoutMilliseconds": 2000,


### PR DESCRIPTION
…. This value is no longer needed.

### Testing
To test this, basically we need to execute an installation and check that it is executed with no errors. 
