### PR TITLE
[106] Makes the roster card -View More option- accessible by keyboard.

### DIFF
--- a/EdFi.Buzz.UI/src/Components/Header/index.tsx
+++ b/EdFi.Buzz.UI/src/Components/Header/index.tsx
@@ -270,9 +270,9 @@ export const Header: FunctionComponent<HeaderComponentProps> = (
         <HeaderLogo><HeaderImage src={props.titleLogo} alt={props.title} /></HeaderLogo>
         <MainNav>
           <ul>
-            <li> <CustomLink to="/" activeOnlyWhenExact={true}>Class Roster</CustomLink> </li>
-            <li> <CustomLink to="/surveyAnalytics">Surveys</CustomLink> </li>
-            <li>
+            <li tabIndex={1}> <CustomLink to="/" activeOnlyWhenExact={true}>Class Roster</CustomLink> </li>
+            <li tabIndex={1}> <CustomLink to="/surveyAnalytics">Surveys</CustomLink> </li>
+            <li tabIndex={1}>
               <LoggedUserMenu onClick={() => setMenuActive(!menuActive)} >
                 <LoggedUser>
                   {`${teacher.firstname} ${teacher.lastsurname}`} &nbsp;<MenuArrow src={ArrowDown}></MenuArrow>&nbsp;&nbsp;
@@ -280,21 +280,21 @@ export const Header: FunctionComponent<HeaderComponentProps> = (
                 <MenuOptions className={menuActive ? 'active' : ''}>
                   <ul>
                     {isAdminSurveyLoader
-                      ? <li>
+                      ? <li tabIndex={1}>
                         <Link to="/adminSurvey">
                           <LinkButton><Icon icon={mdBuild}></Icon>&nbsp;Admin Survey</LinkButton>
                         </Link>
                       </li>
                       : null}
                     {isAdminSurveyLoader || isTeacherSurveyLoader
-                      ? <li>
+                      ? <li tabIndex={1}>
                         <Link to="/uploadSurvey">
                           <LinkButton><Icon icon={mdUpload}></Icon>&nbsp;Upload Survey</LinkButton>
                         </Link>
                       </li>
                       : null}
                     <LoadOdsSurveysMenuOption isAdminSurveyLoader={isAdminSurveyLoader} api={props.api}/>
-                    <li>
+                    <li tabIndex={1}>
                       <Link to="/Login">
                         <LinkButton onClick={logOut}><Icon icon={mdUnlock}></Icon>&nbsp;LogOut</LinkButton>
                       </Link>

--- a/EdFi.Buzz.UI/src/Components/SearchInSections/searchInSections.tsx
+++ b/EdFi.Buzz.UI/src/Components/SearchInSections/searchInSections.tsx
@@ -212,6 +212,7 @@ export const SearchInSections: React.FunctionComponent<SearchInSectionsComponent
         <StyledSelectParent id='sectionsSelectParent'>
           <FilterByClassLabelDesktop>Filter by Class:</FilterByClassLabelDesktop>
           <select
+            tabIndex={2}
             name='repeatSelect'
             id='sectionsSelect'
             value={defaultValue}
@@ -229,6 +230,7 @@ export const SearchInSections: React.FunctionComponent<SearchInSectionsComponent
         <StyledTextParent>
           <img src={OrangeSearch} alt="Search" />
           <input
+            tabIndex={2}
             type='text'
             id='searchFilter'
             placeholder={ (props.searchFilterPlaceholder || 'Search by Student Name') }

--- a/EdFi.Buzz.UI/src/Feature/StudentRoster/studentCard.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentRoster/studentCard.tsx
@@ -6,7 +6,7 @@
 import styled from 'styled-components';
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import * as React from 'react';
 import Student from '../../Models/Student';
 
@@ -180,12 +180,26 @@ export interface StudentCardComponentProps {
 
 export const StudentCard: React.FunctionComponent<StudentCardComponentProps> = (props: StudentCardComponentProps) => {
   const {student} = props;
+  const history = useHistory();
   const [isCollapsed, setIsCollapsed] = useState(false);
+
+  function handleStudentDetailCollapse (event) {
+    if(event.key === 'Enter'){
+      setIsCollapsed(!isCollapsed);
+    }
+  }
+  
+  function handleStudentDetailRedirect (event) {
+    if(event.key === 'Enter'){
+      history.push(`/studentDetail/${student.studentschoolkey}`);
+    }
+  }
+
   return (
     <StyledStudentCard className='card'>
       <div className='student-card-body p-t-0'>
         <div className='d-flex p-t-12'>
-          <Link to={`/studentDetail/${student.studentschoolkey}`}>
+          <Link to={`/studentDetail/${student.studentschoolkey}`} tabIndex={3}>
             <div className='image-container'>
               <img className='student-profile-pic' src={student.pictureurl} alt={`${student.name} Profile`} />
             </div>
@@ -194,8 +208,8 @@ export const StudentCard: React.FunctionComponent<StudentCardComponentProps> = (
             <span className='h2-desktop'>{student.name}</span>
             {student.primaryemailaddress && (
               <div>
-                <EmailIcon />
-                <a
+                <EmailIcon/>
+                <a tabIndex={3}
                   className='m-b-2 text-ellipsis'
                   href={`mailto:${student.primaryemailaddress}`}
                   title={student.primaryemailaddress}
@@ -275,14 +289,14 @@ export const StudentCard: React.FunctionComponent<StudentCardComponentProps> = (
           {(!student.contacts || student.contacts.length === 0) && (
             <div className='alert alert-primary'>Student has no contacts</div>
           )}
-          <div className='outline-button'>
+          <div tabIndex={3} className='outline-button' onKeyPress={handleStudentDetailRedirect}>
             <Link to={`/studentDetail/${student.studentschoolkey}`}>Student Details</Link>
           </div>
         </div>
       </div>
 
       <div className='footer card-footer'>
-        <div className='clickable' onClick={() => setIsCollapsed(!isCollapsed)}>
+        <div className='clickable' onClick={() => setIsCollapsed(!isCollapsed)} tabIndex={3} onKeyPress={handleStudentDetailCollapse}>
           <div>{!isCollapsed ? 'View more' : 'Collapse'}</div>
           <img src={!isCollapsed ? ChevronDown : ChevronUp} onClick={() => setIsCollapsed(!isCollapsed)} alt="" />
         </div>


### PR DESCRIPTION
### About the solution
I am not sure if I am taking the right approach. Don't have much experience using the tab-index attribute. But it seems to be working fine. Tested it with Chrome, Firefox and Edge.
If this is not the right approach please feel free to point it out. 

### Testing.
1. Execute the app, log in and go to the roster page.
2. Click on the URL address bar
3. Start pressing tab and the focus should move this way:
3. a. Class Roster menu option, then Surveys and finally logged in user option.
3. b. Then it will move to the Filter by Class drop down and Search by Student Name input text.
3. c. After that the focus should move to the student card. First the picture, then the email, and then the View More menu option.

Notice that if you press enter on the View More option the card expands and collapses. 
Notice as well that when the card is expanded, you can shift-tab to move to the Student Detail button.

