### PR TITLE
[FIF-333] Makes Roster View Style accesible by the keyboard.

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
@@ -43,10 +43,7 @@ const ListButtons = styled.div`
       outline-width: 0px;
       font-weight: 600;
       text-decoration: underline;
-    }
-    :focus {
-      outline-width: 0px;
-    }
+    }y
   }
 `;
 
@@ -91,8 +88,8 @@ export const StudentRoster: FunctionComponent<StudentRosterComponentProps> = (pr
       {studentList.length > 0 && (
         <ListButtons>
           <span>View Style:</span>
-          <button onClick={() => setViewType(ViewTypes.Grid)}>Grid</button>|
-          <button onClick={() => setViewType(ViewTypes.Card)}>Cards</button>
+          <button onClick={() => setViewType(ViewTypes.Grid)} tabIndex={3}>Grid</button>|
+          <button onClick={() => setViewType(ViewTypes.Card)} tabIndex={3}>Cards</button>
         </ListButtons>
       )}
 

--- a/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentRoster/index.tsx
@@ -43,7 +43,7 @@ const ListButtons = styled.div`
       outline-width: 0px;
       font-weight: 600;
       text-decoration: underline;
-    }y
+    }
   }
 `;
 


### PR DESCRIPTION
### Testing.
Execute the app, log in and go to the roster page.
Click on the URL address bar
Start pressing tab and the focus should move this way:
a. Class Roster menu option, then Surveys and finally logged in user option.
b. Then it will move to the Filter by Class drop down and Search by Student Name input text.
c. After that the focus should move to the View Style section. 

Notice that if you press enter on the Grid view or Cards view, the roster should change to that view.