### PR TITLE
[FIF-335] Makes Student detail survey and notes tabs accessible by the keyboard.

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/StudentDetail/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentDetail/index.tsx
@@ -342,7 +342,7 @@ export const StudentDetail: FunctionComponent<StudentDetailProps> = (props: Stud
       {student && (
         <StudentDetailContainer>
           <div className='student-detail-top'>
-            <a href={'/'} className='student-detail-go-back-container'>
+            <a href={'/'} className='student-detail-go-back-container' tabIndex={3}>
               <LeftArrowIcon />
               <div className='student-detail-go-back-label'>Go back to Class Roster</div>
             </a>
@@ -362,6 +362,7 @@ export const StudentDetail: FunctionComponent<StudentDetailProps> = (props: Stud
                           className='text-ellipsis'
                           href={`mailto:${student.primaryemailaddress}`}
                           title={student.primaryemailaddress}
+                          tabIndex={3}
                         >
                           {student.primaryemailaddress}
                         </a>
@@ -418,19 +419,25 @@ export const StudentDetail: FunctionComponent<StudentDetailProps> = (props: Stud
             </div>
             <div className='student-detail-tabbed-container'>
               <div className='student-detail-tabs'>
-                <div
+                <div tabIndex={3}
                   ref={surveyTabRef}
                   className={selectedTabClassName}
                   onClick={() => {
                     toggleTabVisibility(ActiveTabEnum.Surveys);
                   }}
+                  onKeyPress={() => {
+                    toggleTabVisibility(ActiveTabEnum.Surveys);
+                  }}
                 >
                 Surveys
                 </div>
-                <div
+                <div tabIndex={3}
                   ref={notesTabRef}
                   className={unselectedTabClassName}
                   onClick={() => {
+                    toggleTabVisibility(ActiveTabEnum.Notes);
+                  }}
+                  onKeyPress={() => {
                     toggleTabVisibility(ActiveTabEnum.Notes);
                   }}
                 >


### PR DESCRIPTION
### Do not merge this one until we merge the PR for FIF-333

As I mentioned in the PR for FIF-106 and FIF-333, I am not sure if I am taking the right approach. Don't have much experience using the tab-index attribute. But it seems to be working fine. Tested it with Chrome, Firefox and Edge.
If this is not the right approach please feel free to point it out.

### Testing.
Execute the app, log in and go to the roster page and then go to the student detail page of any of the students.
Click on the URL address bar
Start pressing tab and the focus should move this way:
a. Class Roster menu option, then Surveys and finally logged in user option.
b. Then it will move to the student specific fields, first Go back to student roster link, then email.
c. After that the focus should move to the tabs: Survey tab and Notes tab.

Notice that if you press enter on the tabs, that section should be shows. 