### PR TITLE
[FIF-334] Makes student detail survey expansion accessible by the keyboard.

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailNote.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailNote.tsx
@@ -72,6 +72,8 @@ export const StudentDetailNote: FunctionComponent<StudentDetailNoteProps> = (pro
               <StyledBuzzButton
                 className='Edit Note'
                 onClick={() => props.deleteNoteFunc(note.staffkey, note.studentnotekey)}
+                onKeyPress={() => props.deleteNoteFunc(note.staffkey, note.studentnotekey)}
+                tabIndex={3}
               >
                 Delete Note
               </StyledBuzzButton>

--- a/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailNotesContainer.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailNotesContainer.tsx
@@ -159,6 +159,10 @@ export const StudentDetailNotesContainer: FunctionComponent<StudentDetailNotesCo
                 onClick={() => {
                   addStudentNote();
                 }}
+                onKeyPress={() => {
+                  addStudentNote();
+                }}
+                tabIndex={3}
               >
                 Add a note
               </StyledBuzzButton>

--- a/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailSurvey.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentDetail/StudentDetailSurvey.tsx
@@ -20,10 +20,7 @@ const StyledStudentSurveyRow = styled.div`
   .stacked-container {
     display: flex;
     flex-direction: column;
-  }
-
-  & > div {
-    flex: 0 0 100%;
+    flex: 0 0 94%;
   }
 
   .survey-question-row {
@@ -50,8 +47,9 @@ const StyledStudentSurveyRow = styled.div`
 const StyledChevronIcon = styled.div`
   flex: 1;
   padding-right: 1.5rem;
-  width: 22px;
-  height: 12px;
+  padding-left: 5px;
+  width: 20px;
+  height: 25px;
   cursor: pointer;
 `;
 
@@ -84,7 +82,7 @@ export const StudentDetailSurvey: FunctionComponent<StudentDetailSurveyProps> = 
                 <div className='bold'>Questions:&nbsp;{survey.answers.length}</div>
               </div>
             </div>
-            <StyledChevronIcon onClick={() => toggleDetail()}>
+            <StyledChevronIcon onClick={() => toggleDetail()} tabIndex={3} onKeyPress={() => toggleDetail()}>
               {!show ? <ChevronDownIcon /> : <ChevronUpIcon />}
             </StyledChevronIcon>
           </StyledStudentSurveyRow>

--- a/EdFi.Buzz.UI/src/globalstyle.ts
+++ b/EdFi.Buzz.UI/src/globalstyle.ts
@@ -23,11 +23,6 @@ export const StyledBuzzButton = styled.button`
   border-radius: 4px;
   margin: .5rem 1rem;
 
-  &:focus {
-    border: none;
-    outline: none;
-  }
-
   &:active {
     background-color: var(--denim);
     border: none;


### PR DESCRIPTION
### Testing.
Execute the app, log in and go to the roster page and then go to the student detail page of any of the students.
Click on the URL address bar
Start pressing tab and the focus should move this way:
a. Class Roster menu option, then Surveys and finally logged in user option.
b. Then it will move to the student specific fields, first Go back to student roster link, then email.
c. After that the focus should move to the tabs: Survey tab and Notes tab.
d. Finally, you should be able to move to the survey answers. 
e. Additionally, you should be able to go to the notes, add notes, delete notes, etc.
