### PR TITLE
[FIF-336] The survey viewer needs to have the surveys accessible by the keyboard

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/StudentRoster/studentCard.tsx
+++ b/EdFi.Buzz.UI/src/Feature/StudentRoster/studentCard.tsx
@@ -188,7 +188,7 @@ export const StudentCard: React.FunctionComponent<StudentCardComponentProps> = (
       setIsCollapsed(!isCollapsed);
     }
   }
-  
+
   function handleStudentDetailRedirect (event) {
     if(event.key === 'Enter'){
       history.push(`/studentDetail/${student.studentschoolkey}`);

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
@@ -81,6 +81,8 @@ export const SurveyMetadataUI: React.FunctionComponent<SurveyMetadataUIComponent
       {props.surveyMetadataList.map((surveyMetadata, idx) => (
         <Link
           key={surveyMetadata.surveykey}
+          onKeyPress={(event) => event.key === 'Enter' ? props.onSurveySelected(surveyMetadata) : null}
+          tabIndex={3}
           className={'col-12 col-md-6' }
           to={{
             pathname: '/surveyAnswersDetail',
@@ -89,7 +91,6 @@ export const SurveyMetadataUI: React.FunctionComponent<SurveyMetadataUIComponent
           <SurveyStyledCardContainer
             className={`${surveyMetadata.surveykey === props.selectedSurveyKey ? 'survey-selected' : null}`}
             key={surveyMetadata.surveykey}
-            onKeyPress={(event) => event.key === 'Enter' ? props.onSurveySelected(surveyMetadata) : null}
           >
             <SurveyStyledCard className='card survey-metadata' color={colorList[idx % 6]}>
               <div className={'card-body'}>

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
@@ -79,19 +79,18 @@ export const SurveyMetadataUI: React.FunctionComponent<SurveyMetadataUIComponent
         </div>
       )}
       {props.surveyMetadataList.map((surveyMetadata, idx) => (
-        <Link
+        <SurveyStyledCardContainer
+          className={`col-12 col-md-6 ${surveyMetadata.surveykey === props.selectedSurveyKey ? 'survey-selected' : null}`}
           key={surveyMetadata.surveykey}
-          onKeyPress={(event) => event.key === 'Enter' ? props.onSurveySelected(surveyMetadata) : null}
-          tabIndex={3}
-          className={'col-12 col-md-6' }
-          to={{
-            pathname: '/surveyAnswersDetail',
-            state: {surveyMetadata}
-          }}>
-          <SurveyStyledCardContainer
-            className={`${surveyMetadata.surveykey === props.selectedSurveyKey ? 'survey-selected' : null}`}
+        >
+          <Link
             key={surveyMetadata.surveykey}
-          >
+            onKeyPress={(event) => event.key === 'Enter' ? props.onSurveySelected(surveyMetadata) : null}
+            tabIndex={3}
+            to={{
+              pathname: '/surveyAnswersDetail',
+              state: {surveyMetadata}
+            }}>
             <SurveyStyledCard className='card survey-metadata' color={colorList[idx % 6]}>
               <div className={'card-body'}>
                 <div className={'survey-card-container survey-metadata-container'}>
@@ -109,8 +108,8 @@ export const SurveyMetadataUI: React.FunctionComponent<SurveyMetadataUIComponent
                 </div>
               </div>
             </SurveyStyledCard>
-          </SurveyStyledCardContainer>
-        </Link>
+          </Link>
+        </SurveyStyledCardContainer>
       ))}
     </>
   );

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyMetadataUI.tsx
@@ -89,7 +89,7 @@ export const SurveyMetadataUI: React.FunctionComponent<SurveyMetadataUIComponent
           <SurveyStyledCardContainer
             className={`${surveyMetadata.surveykey === props.selectedSurveyKey ? 'survey-selected' : null}`}
             key={surveyMetadata.surveykey}
-
+            onKeyPress={(event) => event.key === 'Enter' ? props.onSurveySelected(surveyMetadata) : null}
           >
             <SurveyStyledCard className='card survey-metadata' color={colorList[idx % 6]}>
               <div className={'card-body'}>


### PR DESCRIPTION
You can tab through the actual survey cards. If a card is selected and the user press enter, it should redirect to survey answers detail page.
![image](https://user-images.githubusercontent.com/56046999/98604337-190c8380-22a9-11eb-91a4-0757170290e0.png)
