### PR TITLE
[FIF-337] Added tab navigation Survey answer page.

### DIFF
--- a/EdFi.Buzz.UI/src/Components/DataTable/dataTable.tsx
+++ b/EdFi.Buzz.UI/src/Components/DataTable/dataTable.tsx
@@ -278,12 +278,14 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
             return (
               <th
                 onClick={() => sortByEventHandler(index)}
+                onKeyPress={(event) => event.key === 'Enter' ? sortByEventHandler(index) : null}
                 className={
                   (index !== sortByColIndex ? 'sorting ' : '') +
                   (index === sortByColIndex && !sortDirection.Descending ? 'sorting_asc ' : '') +
                   (index === sortByColIndex && sortDirection.Descending ? 'sorting_desc' : '')
                 }
                 key={label}
+                tabIndex={3}
               >
                 {label}
               </th>
@@ -322,7 +324,7 @@ export const DataTable: React.FunctionComponent<DataTableComponentProps> = (prop
                   }
                 >
                   {isColumnOption(labelColumn) && labelColumn.linkColumnIndex >= 0 ? (
-                    <a href={`${props.linkBaseURL}${row[labelColumn.linkColumnIndex]}`}>{column}</a>
+                    <a tabIndex={3} href={`${props.linkBaseURL}${row[labelColumn.linkColumnIndex]}`}>{column}</a>
                   ) : (
                     <>{column}</>
                   )}

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyAnswersSummary.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyAnswersSummary.tsx
@@ -35,7 +35,6 @@ const SurveyStyledCard = styled(StyledCard)`
 `;
 
 const SurveyAnswersSummary: FunctionComponent<SurveyAnswersSummaryProps> = ({ api, selectedSurveyMetadata }) => {
-
   const [surveyMetadataList] = useState(selectedSurveyMetadata);
   const [selectedQuestionIndex, setSelectedQuestionIndex] = useState(null as number);
   const [selectedAnswer, setSelectedAnswer] = useState(null as string);
@@ -129,6 +128,7 @@ const SurveyAnswersSummary: FunctionComponent<SurveyAnswersSummaryProps> = ({ ap
                           {question.question}
                         </SurveyTitle>
                       }
+                      index={index}
                       afterSelectionChangedHandler={(answer: string) => onSurveyAnswerSelected(answer, index)}
                     />
                   </div>

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import SurveyQuestionSummary from 'Models/SurveyQuestionSummary';
+import { createRef, useEffect } from 'react';
 import { SurveyChart } from './surveyChart';
 import SurveyWordCloud from './surveyWordCloud';
 import { DataTable , ColumnOption } from '../../Components/DataTable/dataTable';
@@ -13,11 +14,13 @@ import ChevronDown from '../../assets/chevron-down.png';
 import ChevronUp from '../../assets/chevron-up.png';
 
 
+
 export interface ChartAndTableComponentProps {
   question: SurveyQuestionSummary;
   columns: string[] | ColumnOption[];
   dataSet: string[][];
   title?: string | React.ReactElement;
+  index?: number ;
   afterSelectionChangedHandler?: (newSelection: string) => void;
 }
 
@@ -43,6 +46,13 @@ export const ChartAndTable: React.FunctionComponent<ChartAndTableComponentProps>
   const selectedQuestion = props.question;
   const [viewAnswersByStudent, setViewAnswersByStudent] = React.useState(false);
   const [selectedAnswer, setSelectedAnswer] = React.useState(null as string);
+  const surveyViewDetailRef = createRef<HTMLDivElement>();
+
+  useEffect(() => {
+    if(props.index===0){
+      surveyViewDetailRef.current.focus();
+    }
+  }, [props.index,surveyViewDetailRef]);
 
   function onAnswerSelectionChangedHandler(answer: string) {
     setSelectedAnswer(answer);
@@ -66,7 +76,9 @@ export const ChartAndTable: React.FunctionComponent<ChartAndTableComponentProps>
       tabIndex={3}
       onClick={() => setViewAnswersByStudent(!viewAnswersByStudent)}
       onKeyPress={(event) => event.key === 'Enter' ? setViewAnswersByStudent(!viewAnswersByStudent) : null}
-      className={'view-answers-by-student'}>
+      className={'view-answers-by-student'}
+      ref={surveyViewDetailRef}
+    >
       <div>View Answers by Student<img src={!viewAnswersByStudent ? ChevronDown : ChevronUp} alt=""/></div>
     </StyledSurveyArea>
 

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
@@ -62,7 +62,11 @@ export const ChartAndTable: React.FunctionComponent<ChartAndTableComponentProps>
       question={selectedQuestion}
     />
     }
-    <StyledSurveyArea onClick={() => setViewAnswersByStudent(!viewAnswersByStudent)} className={'view-answers-by-student'}>
+    <StyledSurveyArea
+      tabIndex={3}
+      onClick={() => setViewAnswersByStudent(!viewAnswersByStudent)}
+      onKeyPress={(event) => event.key === 'Enter' ? setViewAnswersByStudent(!viewAnswersByStudent) : null}
+      className={'view-answers-by-student'}>
       <div>View Answers by Student<img src={!viewAnswersByStudent ? ChevronDown : ChevronUp} alt=""/></div>
     </StyledSurveyArea>
 


### PR DESCRIPTION
Survey  'View Answers by Student' link accesible by tabs
1 Enter the Surveys menu.
2 Select a section with surveys and select a survey.
3 On the answers detail page, when the chart are displayed, use the tab to navigate.
4 You must be able to access, through the tab, the 'View Answers by Student' link. If you press enter the tables are displayed.
5 You can navigate in the tables, both in the header, and in the student link, using the tab.