### PR TITLE
[FIF-331] Word cloud updated to be click-able to filter results

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyChartAndTable.tsx
@@ -70,6 +70,7 @@ export const ChartAndTable: React.FunctionComponent<ChartAndTableComponentProps>
     {selectedQuestion.answers.length >= 10 &&
     <SurveyWordCloud title={props.title}
       question={selectedQuestion}
+      afterSelectionChangedHandler={onAnswerSelectionChangedHandler}
     />
     }
     <StyledSurveyArea

--- a/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyWordCloud.tsx
+++ b/EdFi.Buzz.UI/src/Feature/SurveyAnalytics/surveyWordCloud.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import 'd3-transition';
+import { select } from 'd3-selection';
 import ReactWordcloud from 'react-wordcloud';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/animations/scale.css';
@@ -7,11 +9,13 @@ import SurveyQuestionSummary from 'Models/SurveyQuestionSummary';
 export interface SurveyWordCloudProps {
   title?: string | React.ReactElement;
   question: SurveyQuestionSummary;
+  afterSelectionChangedHandler?: (newSelection: string) => void;
 }
 
 const SurveyWordCloud: React.FunctionComponent<SurveyWordCloudProps> = (props: SurveyWordCloudProps) => {
   const {question} = props;
   const [data,setData] = useState([]);
+  const [selectedAnswer, setSelectedAnswer] = React.useState(null);
 
   useEffect(() => {
     const answers = question.answers.map(k =>
@@ -19,8 +23,20 @@ const SurveyWordCloud: React.FunctionComponent<SurveyWordCloudProps> = (props: S
     );
     setData(answers);
   }, [question.answers]);
+
   const callbacks =  {
-    getWordTooltip: word => `<b>${word.text}</b><p>${question.question}: ${word.value}</p>`
+    getWordTooltip: word => `<b>${word.text}</b><p>${question.question}: ${word.value}</p>`,
+    onWordClick: (word, event) =>{
+      const newSelectedAnswer = selectedAnswer !== word.text ? word.text : null;
+      const text = select(event.target);
+      text
+        .transition()
+        .attr('text-decoration', 'underline');
+      setSelectedAnswer(newSelectedAnswer);
+      if (props.afterSelectionChangedHandler) {
+        props.afterSelectionChangedHandler(newSelectedAnswer);
+      }
+    }
   };
   return <>
     {(props.title) && <h2>{props.title}</h2>}


### PR DESCRIPTION
1. Select a survey that displays a word cloud.
![Capture](https://user-images.githubusercontent.com/56046999/98967380-0aed7b80-24d2-11eb-8ea0-ad621c8bcbee.PNG)

2. When selecting the answers, the detail will be filtered by the answer, when clicking on it, the filter is removed.

