### PR TITLE
[FIF-327] Update readme notes for CORS

### DIFF
--- a/EdFi.Buzz.Installer/eng/README.md
+++ b/EdFi.Buzz.Installer/eng/README.md
@@ -91,6 +91,7 @@ Options to configure the ETL to load from the database or file to the postgres d
 - **url:**  URL for the GraphQL endpoint setting in the UI env file.
 - **port:** API port.
 - **surveyFilesFolder** The folder into which uploaded survey files are written
+- **corsOrigins** This is a comma-delimited list of URIs which require API access. CORS policy will reject any URIs not in this list. Include the protocol (http or https).
 
 #### ui
 

--- a/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
+++ b/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
@@ -48,7 +48,8 @@
         "version": null,
         "url": "http://localhost:3000",
         "port": 3000,
-        "surveyFilesFolder": "C:\\Ed-Fi\\Buzz\\surveys"
+        "surveyFilesFolder": "C:\\Ed-Fi\\Buzz\\surveys",
+        "corsOrigins": "http://localhost,https://localhost,http://another.api.consumer.local"
     },
     "ui": {
         "version": null,


### PR DESCRIPTION
This PR updates the Installer Readme to include the usage notes for the api corsOrigins setting. The example configuration.json file is also updated.

### NOTE: This PR should merge only after FIF-48 has been merged, and should require a rebase.