### PR TITLE
[FIF-352] Includes chronic absenteeism data from AMT in the ETL scripts.

### DIFF
--- a/EdFi.Buzz.Database/migrations/sample-data/sqls/20201022195215-adds-sample-data-up.sql
+++ b/EdFi.Buzz.Database/migrations/sample-data/sqls/20201022195215-adds-sample-data-up.sql
@@ -410,7 +410,6 @@ VALUES
   (2000000016, 2000000006, '6 p.m. to 9 p.m.'),
   (2000000016, 2000000007, 'Leave a message and they will call back');
 
-
 -- STUDENT NOTES
 
 delete from buzz.studentnote;
@@ -426,5 +425,39 @@ VALUES
   (2000000005, 'This is a sample note for Fran Lemay',          '100005-100001', 100003, NOW()),
   (2000000006, 'This is a sample note for Andrew Henderson',    '100006-100001', 100003, NOW()),
   (2000000007, 'This is a sample note for Irene Alfaro',        '100007-100001', 100003, NOW()),
-  (2000000008, 'This is a sample note for Rebecca Numbers',     '100008-100001', 100003, NOW())
-  
+  (2000000008, 'This is a sample note for Rebecca Numbers',     '100008-100001', 100003, NOW());
+
+-- STUDENT ATTENDANCE
+
+WITH source AS (VALUES
+	('100001-100001', 98.10, 1.90, 94.50, 5.50, 96.30, 3.70),
+  ('100002-100001', 92.60, 7.40, 95.00, 5.00, 96.60, 3.40),
+  ('100003-100001', 93.90, 6.10, 94.20, 5.80, 96.70, 3.30),
+  ('100004-100001', 91.90, 8.10, 99.80, 1.20, 98.40, 1.60),
+  ('100005-100001', 92.20, 7.80, 89.90, 10.10, 97.50, 2.50),
+  ('100006-100001', 90.90, 9.10, 91.40, 8.60, 97.70, 2.30),
+  ('100007-100001', 97.40, 2.60, 98.10, 1.90, 90.00, 10.00),
+  ('100008-100001', 99.90, 0.01, 98.90, 1.10, 99.60, 1.40)
+)
+INSERT INTO 
+    buzz.attendance
+(
+	StudentSchoolKey,
+  ReportedAsPresentAtSchool,
+  ReportedAsAbsentFromSchool,
+  ReportedAsPresentAtHomeRoom,
+  ReportedAsAbsentFromHomeRoom,
+  ReportedAsIsPresentInAllSections,
+  ReportedAsAbsentFromAnySection
+)
+SELECT
+  source.column1,
+  source.column2,
+  source.column3,
+  source.column4,
+  source.column5,
+  source.column6,
+  source.column7
+FROM
+    source
+ON CONFLICT DO NOTHING;

--- a/EdFi.Buzz.Etl/config/dsHelper.js
+++ b/EdFi.Buzz.Etl/config/dsHelper.js
@@ -31,4 +31,32 @@ const dbDataStandard = async (config) => {
   }
 };
 
+const chronicAbsenteeismAttendanceFactExists = async (config) => {
+  try {
+    await sql.connect(config);
+    const result = await sql.query`
+        IF EXISTS
+        (
+            SELECT 1
+            FROM INFORMATION_SCHEMA.VIEWS
+            WHERE TABLE_SCHEMA = 'analytics'
+                  AND TABLE_NAME = 'chrab_ChronicAbsenteeismAttendanceFact'
+        )
+        BEGIN
+            SELECT 'yes' AS 'exists'
+        END
+        ELSE BEGIN
+            SELECT 'no' AS 'exists'
+        END
+        `;
+
+    if (result.recordset && result.recordset.length > 0) return result.recordset[0].exists;
+
+    return undefined;
+  } catch (err) {
+    return undefined;
+  }
+};
+
 exports.dbDataStandard = dbDataStandard;
+exports.chronicAbsenteeismAttendanceFactExists = chronicAbsenteeismAttendanceFactExists;

--- a/EdFi.Buzz.Etl/config/etl.js
+++ b/EdFi.Buzz.Etl/config/etl.js
@@ -16,6 +16,7 @@ const studentContactSource = `${sqlSourceDir}/0004-ImportStudentContact.sql`;
 const sectionSource = `${sqlSourceDir}/0005-ImportSection.sql`;
 const staffSource = `${sqlSourceDir}/0006-ImportStaff.sql`;
 const studentSectionSource = `${sqlSourceDir}/0008-ImportStudentSection.sql`;
+const studentAttendanceSource = `${sqlSourceDir}/0009-ImportChronicAbsenteeismData.sql`;
 
 const schoolSourceSQL = fs.readFileSync(path.join(__dirname, schoolSource), 'utf8');
 const studentSchoolSourceSQL = fs.readFileSync(path.join(__dirname, studentSchoolSource), 'utf8');
@@ -24,6 +25,7 @@ const studentContactSourceSQL = fs.readFileSync(path.join(__dirname, studentCont
 const sectionSourceSQL = fs.readFileSync(path.join(__dirname, sectionSource), 'utf8');
 const staffSourceSQL = fs.readFileSync(path.join(__dirname, staffSource), 'utf8');
 const studentSectionSourceSQL = fs.readFileSync(path.join(__dirname, studentSectionSource), 'utf8');
+const studentAttendanceSourceSQL = fs.readFileSync(path.join(__dirname, studentAttendanceSource), 'utf8');
 
 let staffSectionConfig = {};
 
@@ -201,5 +203,24 @@ exports.studentSectionConfig = {
     row.studentsectionenddatekey,
     row.schoolkey,
     row.schoolyear,
+  ],
+};
+
+exports.studentAttendanceConfig = {
+  recordType: 'Attendance',
+  selectSql: 'SELECT 1 FROM buzz.attendance WHERE studentschoolkey=$1',
+  insertSql: 'INSERT INTO buzz.attendance (studentschoolkey, reportedaspresentatschool, reportedasabsentfromschool, reportedaspresentathomeroom, reportedasabsentfromhomeroom, reportedasispresentinallsections, reportedasabsentfromanysection) VALUES ($1::text, $2, $3, $4, $5, $6, $7)',
+  updateSql: 'UPDATE buzz.attendance SET reportedaspresentatschool=$2, reportedasabsentfromschool=$3, reportedaspresentathomeroom=$4, reportedasabsentfromhomeroom=$5, reportedasispresentinallsections=$6, reportedasabsentfromanysection=$7 WHERE studentschoolkey=$1',
+  sourceSql: studentAttendanceSourceSQL,
+  keyIndex: 0,
+  isEntityMap: false,
+  valueFunc: (row) => [
+    row.studentschoolkey,
+    row.reportedaspresentatschool,
+    row.reportedasabsentfromschool,
+    row.reportedaspresentathomeroom,
+    row.reportedasabsentfromhomeroom,
+    row.reportedasispresentinallsections,
+    row.reportedasabsentfromanysection,
   ],
 };

--- a/EdFi.Buzz.Etl/sql/amt/0009-ImportChronicAbsenteeismData.sql
+++ b/EdFi.Buzz.Etl/sql/amt/0009-ImportChronicAbsenteeismData.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+SELECT
+    studentschoolkey,
+    cast(sum(ReportedAsPresentAtSchool) * 1.0 / count(DateKey) as numeric(5,2)) as reportedaspresentatschool,
+    cast(sum(ReportedAsAbsentFromSchool) * 1.0 / count(DateKey) as numeric(5,2)) as reportedasabsentfromschool,
+    cast(sum(ReportedAsAbsentFromSchoolReportedAsPresentAtHomeRoom) * 1.0 / count(DateKey) as numeric(5,2)) as reportedaspresentathomeroom,
+    cast(sum(ReportedAsAbsentFromHomeRoom) * 1.0 / count(DateKey) as numeric(5,2)) as reportedasabsentfromhomeroom,
+    cast(sum(ReportedAsIsPresentInAllSections) * 1.0 / count(DateKey) as numeric(5,2)) as reportedasispresentinallsections,
+    cast(sum(ReportedAsAbsentFromAnySection) * 1.0 / count(DateKey) as numeric(5,2)) as reportedasabsentfromanysection
+FROM analytics.chrab_ChronicAbsenteeismAttendanceFact
+GROUP BY StudentSchoolKey
+ORDER BY StudentSchoolKey;

--- a/EdFi.Buzz.Etl/sql/ods/0009-ImportChronicAbsenteeismData.sql
+++ b/EdFi.Buzz.Etl/sql/ods/0009-ImportChronicAbsenteeismData.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+-- Chronic absenteeism is supported when AMT is installed.

--- a/EdFi.Buzz.Etl/src/dbETL.js
+++ b/EdFi.Buzz.Etl/src/dbETL.js
@@ -11,6 +11,7 @@ const config = require('../config/dbs');
 const etl = require('../config/etl');
 const loadMsSqlData = require('./loadMsSqlData');
 const odsSurveyProcessor = require('../processors/odsSurveyProcessor');
+const dsHelper = require('../config/dsHelper');
 
 const pg = config.pgConfig;
 const ms = config.mssqlConfig;
@@ -29,6 +30,16 @@ const loadBaseEntities = async () => {
     await loadMsSqlData.loadMsSqlData(pg, ms, etl.staffSectionConfig());
     await loadMsSqlData.loadMsSqlData(pg, ms, etl.studentSectionConfig);
     await loadMsSqlData.loadMsSqlData(pg, ms, etl.studentContactConfig);
+
+    if (process.env.BUZZ_SQLSOURCE === 'amt') {
+      const viewExists = await dsHelper.chronicAbsenteeismAttendanceFactExists(ms);
+      if (viewExists === 'yes') {
+        await loadMsSqlData.loadMsSqlData(pg, ms, etl.studentAttendanceConfig);
+      } else {
+        console.log('chrab_ChronicAbsenteeismAttendanceFact is not installed');
+      }
+    }
+
     console.log('finished loading entities');
 
     if (process.env.KeepSurveysSynch && process.env.KeepSurveysSynch.toLowerCase() === 'true') {

--- a/EdFi.Buzz.Etl/src/loadMsSqlData.js
+++ b/EdFi.Buzz.Etl/src/loadMsSqlData.js
@@ -47,10 +47,7 @@ const processEntity = async (values, pgClient, rowConfig) => {
     .then(async (res) => {
       if (res.rowCount === 0) {
         await pgClient.query(rowConfig.insertSql, values)
-          .catch(() => {
-            console.error('error');
-            console.error(JSON.stringify(values));
-          });
+          .catch(() => console.error(JSON.stringify(values)));
       }
 
       if (res.rowCount === 1) {

--- a/EdFi.Buzz.Etl/src/loadMsSqlData.js
+++ b/EdFi.Buzz.Etl/src/loadMsSqlData.js
@@ -47,7 +47,10 @@ const processEntity = async (values, pgClient, rowConfig) => {
     .then(async (res) => {
       if (res.rowCount === 0) {
         await pgClient.query(rowConfig.insertSql, values)
-          .catch(() => console.error(JSON.stringify(values)));
+          .catch(() => {
+            console.error('error');
+            console.error(JSON.stringify(values));
+          });
       }
 
       if (res.rowCount === 1) {


### PR DESCRIPTION
### Scenarios we can test:
1. In your env file set the BUZZ_SQLSOURCE value to ods. Chronic absenteeism data is not imported.
2. In your env file set the BUZZ_SQLSOURCE value to amt, and in your ODS_DBNAME select a database with AMT but without the chrab_ChronicAbsenteeismAttendanceFact View. Chronic absenteeism data is not imported.
3. In your env file set the BUZZ_SQLSOURCE value to amt, and in your ODS_DBNAME select a database with AMT and with the chrab_ChronicAbsenteeismAttendanceFact View. Chronic absenteeism data is imported this time.
### Other scenario in the database project.
On an empty database, execute yarn migrate first, to execute the migrations, and then execute yarn sample-data. Notice that some sample data for the attendance table is inserted. 
