### PR TITLE
[FIF-381] Adds CA cert and TLS reject settings to API installer

### DIFF
--- a/EdFi.Buzz.Api/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Api/eng/Windows/install.ps1
@@ -156,7 +156,7 @@ function New-DotEnvFile {
     $extraCaCertsText="NODE_EXTRA_CA_CERTS=$extraCaCerts`n"
   }
 
-  if($tlsRejectUnauthorized -eq $false) {
+  if($rejectTlsUnauthorized -eq $false) {
     $tlsRejectUnauthorizedText="NODE_TLS_REJECT_UNAUTHORIZED=0`n"
   }
 
@@ -190,8 +190,6 @@ SURVEY_MAX_FILE_SIZE_BYTES=1mb
 SURVEY_PROCESS_INITIAL_STATUS_KEY=1
 SURVEY_FILES_RETENTION_DAYS=1
 KEEP_SURVEY_SYNCH=$KeepSurveysSynch
-$extraCaCertsText
-$tlsRejectUnauthorizedText
 "@
   }
   else {

--- a/EdFi.Buzz.Api/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Api/eng/Windows/install.ps1
@@ -83,7 +83,15 @@ param(
 
   [Parameter(Mandatory = $true)]
   [string]
-  $corsOrigins
+  $corsOrigins,
+
+  [Parameter(Mandatory = $true)]
+  [boolean]
+  $rejectTlsUnauthorized = $true,
+
+  [Parameter(Mandatory = $false)]
+  [string]
+  $extraCaCerts
 )
 
 function Get-FileNameWithoutExtensionFromUrl {
@@ -141,10 +149,20 @@ function Install-WebApplication {
 
 function New-DotEnvFile {
   $envFile = ""
+  $extraCaCertsText=""
+  $tlsRejectUnauthorizedText="NODE_TLS_REJECT_UNAUTHORIZED=1`n"
+
+  if(-not [string]::IsNullOrEmpty($extraCaCerts)) {
+    $extraCaCertsText="NODE_EXTRA_CA_CERTS=$extraCaCerts`n"
+  }
+
+  if($tlsRejectUnauthorized -eq $false) {
+    $tlsRejectUnauthorizedText="NODE_TLS_REJECT_UNAUTHORIZED=0`n"
+  }
 
   if ("google" -eq $idProvider) {
     $envFile = @"
-NODE_TLS_REJECT_UNAUTHORIZED=1
+$tlsRejectUnauthorizedText$extraCaCertsText
 BUZZ_API_CORS_ORIGINS='$corsOrigins'
 BUZZ_API_DB_HOST=$DbServer
 BUZZ_API_DB_PORT=$DbPort
@@ -172,11 +190,13 @@ SURVEY_MAX_FILE_SIZE_BYTES=1mb
 SURVEY_PROCESS_INITIAL_STATUS_KEY=1
 SURVEY_FILES_RETENTION_DAYS=1
 KEEP_SURVEY_SYNCH=$KeepSurveysSynch
+$extraCaCertsText
+$tlsRejectUnauthorizedText
 "@
   }
   else {
     $envFile = @"
-NODE_TLS_REJECT_UNAUTHORIZED=1
+$tlsRejectUnauthorizedText$extraCaCertsText
 BUZZ_API_CORS_ORIGINS='$corsOrigins'
 BUZZ_API_DB_HOST=$DbServer
 BUZZ_API_DB_PORT=$DbPort
@@ -204,7 +224,6 @@ SURVEY_MAX_FILE_SIZE_BYTES=1mb
 SURVEY_PROCESS_INITIAL_STATUS_KEY=1
 SURVEY_FILES_RETENTION_DAYS=1
 KEEP_SURVEY_SYNCH=$KeepSurveysSynch
-
 "@
   }
   $envFile | Out-File "$script:installPath\dist\.env" -Encoding UTF8 -Force

--- a/EdFi.Buzz.Installer/eng/README.md
+++ b/EdFi.Buzz.Installer/eng/README.md
@@ -92,6 +92,8 @@ Options to configure the ETL to load from the database or file to the postgres d
 - **port:** API port.
 - **surveyFilesFolder** The folder into which uploaded survey files are written
 - **corsOrigins** This is a comma-delimited list of URIs which require API access. CORS policy will reject any URIs not in this list. Include the protocol (http or https).
+- **rejectTlsUnauthorized** true/false value to bypass the server certificate validation callback.
+- **extraCaCerts** Comma-delimited list of file system paths to your organization's root CA certificates for that server. Export from your certificate store.
 
 #### ui
 

--- a/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
+++ b/EdFi.Buzz.Installer/eng/Windows/Application/appinstalls.psm1
@@ -74,32 +74,34 @@ function Install-ApiApp {
     }
 
     $params = @{
-        "InstallPath"        = Join-Path $configuration.InstallPath "API";
-        "DbServer"           = $configuration.postgresDatabase.host;
-        "DbPort"             = $configuration.postgresDatabase.port;
-        "DbUserName"         = $configuration.postgresDatabase.username;
-        "DbPassword"         = $configuration.postgresDatabase.password;
-        "DbName"             = $configuration.postgresDatabase.database;
-        "idProvider"         = $configuration.idProvider;
-        "uriDiscovery"       = "";
-        "googleClientID"     = $configuration.googleClientID;
-        "clientSecret"       = $configuration.clientSecret;
-        "googleAuthCallback" = $configuration.api.url;
-        "surveyFilesFolder"  = $configuration.api.surveyFilesFolder;
-        "port"               = $configuration.api.Port;
-        "toolsPath"          = $toolsPath;
-        "packagesPath"       = $packagesPath;
-        "SqlServerHost"      = $configuration.sqlServerDatabase.host;
-        "SqlServerPort"      = $configuration.sqlServerDatabase.port;
-        "SqlServerUserName"  = $configuration.sqlServerDatabase.username;
-        "SqlServerPassword"  = $configuration.sqlServerDatabase.password;
-        "SqlServerDbName"    = $configuration.sqlServerDatabase.database;
-        "KeepSurveysSynch"   = $configuration.keepSurveysSynch;
-        "internalRoute"      = $configuration.api.internalRoute;
-        "externalRoute"      = $configuration.api.externalRoute;
-        "corsOrigins"        = $configuration.api.corsOrigins;
-        "rootDir"            = "dist";
-        "app"                = "API";
+        "InstallPath"           = Join-Path $configuration.InstallPath "API";
+        "DbServer"              = $configuration.postgresDatabase.host;
+        "DbPort"                = $configuration.postgresDatabase.port;
+        "DbUserName"            = $configuration.postgresDatabase.username;
+        "DbPassword"            = $configuration.postgresDatabase.password;
+        "DbName"                = $configuration.postgresDatabase.database;
+        "idProvider"            = $configuration.idProvider;
+        "uriDiscovery"          = "";
+        "googleClientID"        = $configuration.googleClientID;
+        "clientSecret"          = $configuration.clientSecret;
+        "googleAuthCallback"    = $configuration.api.url;
+        "surveyFilesFolder"     = $configuration.api.surveyFilesFolder;
+        "port"                  = $configuration.api.Port;
+        "toolsPath"             = $toolsPath;
+        "packagesPath"          = $packagesPath;
+        "SqlServerHost"         = $configuration.sqlServerDatabase.host;
+        "SqlServerPort"         = $configuration.sqlServerDatabase.port;
+        "SqlServerUserName"     = $configuration.sqlServerDatabase.username;
+        "SqlServerPassword"     = $configuration.sqlServerDatabase.password;
+        "SqlServerDbName"       = $configuration.sqlServerDatabase.database;
+        "KeepSurveysSynch"      = $configuration.keepSurveysSynch;
+        "internalRoute"         = $configuration.api.internalRoute;
+        "externalRoute"         = $configuration.api.externalRoute;
+        "corsOrigins"           = $configuration.api.corsOrigins;
+        "rejectTlsUnauthorized" = $configuration.api.rejectTlsUnauthorized;
+        "extraCaCerts"          = $configuration.api.extraCaCerts;
+        "rootDir"               = "dist";
+        "app"                   = "API";
     }
 
     if ("google" -eq $configuration.idProvider) {
@@ -138,12 +140,12 @@ function Install-DatabaseApp {
     }
 
     $params = @{
-        "DbServer"          = $configuration.postgresDatabase.host;
-        "DbPort"            = $configuration.postgresDatabase.port;
-        "DbUserName"        = $configuration.postgresDatabase.username;
-        "DbPassword"        = $configuration.postgresDatabase.password;
-        "DbName"            = $configuration.postgresDatabase.database;
-        "LoadSampleData"    = $configuration.loadSampleData;
+        "DbServer"       = $configuration.postgresDatabase.host;
+        "DbPort"         = $configuration.postgresDatabase.port;
+        "DbUserName"     = $configuration.postgresDatabase.username;
+        "DbPassword"     = $configuration.postgresDatabase.password;
+        "DbName"         = $configuration.postgresDatabase.database;
+        "LoadSampleData" = $configuration.loadSampleData;
     }
 
     Install-BuzzApp -skipFlag $configuration.installDatabase -app "Database" -configuration $configuration -packagesPath $packagesPath -params $params -version $configuration.database.version

--- a/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
+++ b/EdFi.Buzz.Installer/eng/Windows/example.configuration.json
@@ -51,7 +51,9 @@
         "internalRoute": "http://localhost:3000",
         "port": 3000,
         "surveyFilesFolder": "C:\\Ed-Fi\\Buzz\\surveys",
-        "corsOrigins": "http://localhost,http://another.api.consumer.local"
+        "corsOrigins": "http://localhost,http://another.api.consumer.local",
+        "rejectTlsUnauthorized": true,
+        "extraCaCerts": "d:\\glendaleCaCert.cer,d:\\anotherCaCert.cer"
     },
     "ui": {
         "version": null,

--- a/EdFi.Buzz.Installer/eng/Windows/install.ps1
+++ b/EdFi.Buzz.Installer/eng/Windows/install.ps1
@@ -58,7 +58,7 @@ $toolsPath = $conf.toolsPath
 try {
     # Validating Auth configuration
     if (-not (Test-AuthConfiguration -idProvider $conf.idProvider -clientSecret $conf.clientSecret -googleClientId $conf.googleClientId -adfsClientId $conf.adfsClientId -adfsTenantId $conf.adfsTenantId)) {
-        Write-Host "ERROR: Buzz authentication configuration has not been provided properly. Please either provide Google's client identifier and sercret, or ADFS's client and tenant identifiers."
+        Write-Host "ERROR: Buzz authentication configuration has not been provided properly. Please either provide Google's client identifier and secret, or ADFS's client and tenant identifiers."
         exit -1;
     }
 


### PR DESCRIPTION
## OVERVIEW

When merged, this PR will add the ability to configure NODE_EXTRA_CA_CERTS and NODE_TLS_REJECT_UNAUTHORIZED using configuration.json api variables. It also adds the two new settings to the installer readme.

NOTE: The NODE_TLS_REJECT_UNAUTHORIZED defaults to true.

## TO TEST

### EXPECT documentation is updated
Open the installer readme, you should see notes in API for the two new settings.

> IMPORTANT: Before the following install tests, do not forget to build the new API installer package with test.ps1 in the root.

### EXPECT that a false setting turns off Node reject unauthorized; set extraCaCerts to null

1. Set api:rejectTlsUnauthorized to false. and api:enableCaCerts to `null` in your configuration.json and run the installer.
2. Run the installer
3. Open API .env file and confirm that the NODE_TLS_REJECT_UNAUTHORIZED is 0 and there is a blank line beneath and no NODE_EXTRA_CA_CERTS setting.

### EXPECT that a true setting turns on Node reject unauthorized, and a file path sets the NODE_EXTRA_CA_CERTS

1. Set api:rejectTlsUnauthorized to true, and set api:extraCaCerts to `"d:\\rotoCaCert.cer"` in your configuration.json and run the installer.
2. Run the installer
3. Open API .env file and confirm that the NODE_TLS_REJECT_UNAUTHORIZED is 1 and NODE_EXTRA_CA_CERTS is `"d:\\rotoCaCert.cer"`