### PR TITLE
[FIF-380] Fixes broken image icon in header of student detail section.

### DIFF
--- a/EdFi.Buzz.UI/eng/windows/install.ps1
+++ b/EdFi.Buzz.UI/eng/windows/install.ps1
@@ -84,6 +84,8 @@ function Update-Configuration {
   $uriDiscovery = "https://login.microsoftonline.com/common/.well-known/openid-configuration"
   }
 
+  $isExternalLogo = if($externalLogo) {"true"} else {"false"}
+
   $runtimeConfig = @"
 // SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
@@ -97,7 +99,7 @@ window['runConfig'] = {
     REACT_APP_GOOGLE_CLIENT_ID:"$script:googleClientId",
     REACT_APP_ADFS_CLIENT_ID:"$script:adfsClientId",
     REACT_APP_ADFS_TENANT_ID:"$script:adfsTenantId",
-    REACT_APP_EXTERNAL_LOGO:$script:externalLogo,
+    REACT_APP_EXTERNAL_LOGO:$isExternalLogo,
     REACT_APP_LOGO:"$script:logo",
     REACT_APP_LOGO_WIDTH:"$script:logoWidth",
     REACT_APP_TITLE:"$script:title",

--- a/EdFi.Buzz.UI/src/Models/Environment.ts
+++ b/EdFi.Buzz.UI/src/Models/Environment.ts
@@ -21,7 +21,7 @@ export default class Environment {
 
   TITLE: string;
 
-  EXTERNAL_LOGO: string;
+  EXTERNAL_LOGO: boolean;
 
   LOGO: string;
 

--- a/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
+++ b/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
@@ -15,7 +15,7 @@ declare global {
     REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES: string;
     REACT_APP_JOB_STATUS_FINISH_IDS: string;
     REACT_APP_TITLE: string;
-    REACT_APP_EXTERNAL_LOGO: string;
+    REACT_APP_EXTERNAL_LOGO: boolean;
     REACT_APP_LOGO: string;
     REACT_APP_LOGO_WIDTH: string;
     REACT_APP_TITLE_LOGO: string;
@@ -44,7 +44,7 @@ export default class EnvironmentService {
       SURVEY_MAX_FILE_SIZE_BYTES:  Number(runConfig?.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES|| '1048576'),
       JOB_STATUS_FINISH_IDS: JSON.parse(runConfig?.REACT_APP_JOB_STATUS_FINISH_IDS || '[3]'),
       TITLE: runConfig?.REACT_APP_TITLE || process.env.REACT_APP_TITLE,
-      EXTERNAL_LOGO: runConfig?.REACT_APP_EXTERNAL_LOGO || process.env.REACT_APP_EXTERNAL_LOGO,
+      EXTERNAL_LOGO: runConfig?.REACT_APP_EXTERNAL_LOGO || (process.env.REACT_APP_EXTERNAL_LOGO.toLowerCase() === 'true'),
       LOGO: runConfig?.REACT_APP_LOGO || process.env.REACT_APP_LOGO,
       LOGIN_LOGO_WIDTH: runConfig?.REACT_APP_LOGO_WIDTH || process.env.REACT_APP_LOGO_WIDTH,
       TITLE_LOGO: runConfig?.REACT_APP_TITLE_LOGO || process.env.REACT_APP_TITLE_LOGO,

--- a/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
+++ b/EdFi.Buzz.UI/src/Services/EnvironmentService.ts
@@ -44,7 +44,10 @@ export default class EnvironmentService {
       SURVEY_MAX_FILE_SIZE_BYTES:  Number(runConfig?.REACT_APP_SURVEY_MAX_FILE_SIZE_BYTES|| '1048576'),
       JOB_STATUS_FINISH_IDS: JSON.parse(runConfig?.REACT_APP_JOB_STATUS_FINISH_IDS || '[3]'),
       TITLE: runConfig?.REACT_APP_TITLE || process.env.REACT_APP_TITLE,
-      EXTERNAL_LOGO: runConfig?.REACT_APP_EXTERNAL_LOGO || (process.env.REACT_APP_EXTERNAL_LOGO.toLowerCase() === 'true'),
+      EXTERNAL_LOGO: runConfig?.REACT_APP_EXTERNAL_LOGO ||
+        process.env.REACT_APP_EXTERNAL_LOGO
+        ? process.env.REACT_APP_EXTERNAL_LOGO.toLowerCase() === 'true'
+        : false,
       LOGO: runConfig?.REACT_APP_LOGO || process.env.REACT_APP_LOGO,
       LOGIN_LOGO_WIDTH: runConfig?.REACT_APP_LOGO_WIDTH || process.env.REACT_APP_LOGO_WIDTH,
       TITLE_LOGO: runConfig?.REACT_APP_TITLE_LOGO || process.env.REACT_APP_TITLE_LOGO,


### PR DESCRIPTION
### Solution
We have, in our env file a setting to specify if the image should be loaded from the local assets or from an external source. This setting was not being used properly. These changes fix this problem.

### Testing
In the env file change the setting for **REACT_APP_EXTERNAL_LOGO** to false.
Then for **REACT_APP_TITLE_LOGO** setting set a local image from the assets folder. 
Now, log in to the app, go to the student detail page for any student.
Finally, refresh the page and the image should be shown properly.

Now, do the same, but this time change the settings so an external image is used instead of a local one. And the image should be shown properly again.

After testing this on the local development environment. Use the installer to install at least the UI, to confirm it works with the installer app as well. For the installer, the settings involved are: **ui.externalLogo** and **ui.titleLogo**


