### PR TITLE
[FIF-379] Add missing static content to UI web config

### DIFF
--- a/EdFi.Buzz.UI/eng/web.config
+++ b/EdFi.Buzz.UI/eng/web.config
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <configuration>
   <system.webServer>
+    <staticContent>
+      <remove fileExtension=".woff" />
+      <remove fileExtension=".woff2" />
+      <remove fileExtension=".json" />
+      <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+    </staticContent>
     <rewrite>
       <rules>
         <rule name="React Routes" stopProcessing="true">


### PR DESCRIPTION
When merged, this PR allows IIS to serve manifest.json and woff2 file extensions without throwing a 404 error.

> **NOTE:** To test, you need to be running the IIS hosted site.

## TO REPLICATE THE WOFF2 ERROR

- Go to [Buzz on Staging](https://buzz-stg.ed-fi.org) now - as it should present the error.
- Load Buzz UI with Developer console open.
- Expect to see HTTP 404 errors for the woff2.

![image](https://user-images.githubusercontent.com/63315476/101666091-651b2700-3a13-11eb-9042-baa53a1dcf55.png)

## TO REPLICATE THE MANIFEST.JSON ERROR
- Go to [Buzz on Production](https://buzz-demo.ed-fi.org) now - as it should present the error.
- Load Buzz UI with Developer console open to the Application tab.
- Expect to see HTTP 404 errors for manifest.json.

![image](https://user-images.githubusercontent.com/63315476/101666472-de1a7e80-3a13-11eb-9803-a70ee62ce81c.png)


## TO TEST THE FIX

- Check out FIF-379 and install. 
- Load Buzz UI **_from IIS_** with Developer console open.
- Expect that 404s are gone.
