### PR TITLE
[FIF-387] Upgrade highlight.js to 10.4.1

### DIFF
--- a/EdFi.Buzz.Api/package.json
+++ b/EdFi.Buzz.Api/package.json
@@ -43,6 +43,7 @@
     "graphile-worker": "^0.6.0",
     "graphql": "14.5.0",
     "graphql-tools": "6.0.9",
+    "highlight.js": "10.4.1",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.4",
     "mssql": "^6.2.3",

--- a/EdFi.Buzz.Api/yarn.lock
+++ b/EdFi.Buzz.Api/yarn.lock
@@ -5763,6 +5763,11 @@ he@^1.1.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@10.4.1:
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
+  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
+
 highlight.js@^9.6.0:
   version "9.18.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"


### PR DESCRIPTION
Address the dependabot alert to upgrade highlight.js to 10.4.1