### PR TITLE
[FIF-384] Drop and create pgcrypto to generate UUID function

### DIFF
--- a/EdFi.Buzz.Database/migrations/sqls/20201201170923-alter-studentasssessment-up.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20201201170923-alter-studentasssessment-up.sql
@@ -3,6 +3,9 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
+DROP EXTENSION pgcrypto CASCADE;
+CREATE EXTENSION pgcrypto;
+
 ALTER TABLE  buzz.studentassessment
 	ADD studentassessmentkey VARCHAR(45) NOT NULL DEFAULT gen_random_uuid ();
 

--- a/EdFi.Buzz.Database/migrations/sqls/20201201170923-alter-studentasssessment-up.sql
+++ b/EdFi.Buzz.Database/migrations/sqls/20201201170923-alter-studentasssessment-up.sql
@@ -3,7 +3,7 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-DROP EXTENSION pgcrypto CASCADE;
+DROP EXTENSION IF EXISTS pgcrypto CASCADE;
 CREATE EXTENSION pgcrypto;
 
 ALTER TABLE  buzz.studentassessment


### PR DESCRIPTION
gen_random_uuid() is needed to create keys. This functions is required and the cascade is for objects that depend on it - when it already exists.

NOTE: The CASCADE was added to ensure that it can drop when existing objects depend on it. I believe this happened initially when the buzz.studentassessment table already had an studentassessmentkey that depended on that same extension

## TO TEST ON LOCAL DATABASE

- On your local database, you can drop existing objects and re-run the migration.
- Run the following to drop all data and buzz schema objects...
```sql
DROP SCHEMA IF EXISTS buzz CASCADE;
DELETE FROM PUBLIC.migrations;

```
- In EdFi.Buzz.Database, run the migration...
```bash
yarn run migrate
```
- Expect the migration to complete successfully, and re-populate the database with sample data.