### PR TITLE
[FIF-388] Creates a new migration in the sample-data scope to insert attendance…

### DIFF
--- a/EdFi.Buzz.Database/migrations/sample-data/20201210143705-attendance.js
+++ b/EdFi.Buzz.Database/migrations/sample-data/20201210143705-attendance.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201210143705-attendance-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201210143705-attendance-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/EdFi.Buzz.Database/migrations/sample-data/sqls/20201022195215-adds-sample-data-up.sql
+++ b/EdFi.Buzz.Database/migrations/sample-data/sqls/20201022195215-adds-sample-data-up.sql
@@ -426,38 +426,3 @@ VALUES
   (2000000006, 'This is a sample note for Andrew Henderson',    '100006-100001', 100003, NOW()),
   (2000000007, 'This is a sample note for Irene Alfaro',        '100007-100001', 100003, NOW()),
   (2000000008, 'This is a sample note for Rebecca Numbers',     '100008-100001', 100003, NOW());
-
--- STUDENT ATTENDANCE
-
-WITH source AS (VALUES
-	('100001-100001', 98.10, 1.90, 94.50, 5.50, 96.30, 3.70),
-  ('100002-100001', 92.60, 7.40, 95.00, 5.00, 96.60, 3.40),
-  ('100003-100001', 93.90, 6.10, 94.20, 5.80, 96.70, 3.30),
-  ('100004-100001', 91.90, 8.10, 99.80, 1.20, 98.40, 1.60),
-  ('100005-100001', 92.20, 7.80, 89.90, 10.10, 97.50, 2.50),
-  ('100006-100001', 90.90, 9.10, 91.40, 8.60, 97.70, 2.30),
-  ('100007-100001', 97.40, 2.60, 98.10, 1.90, 90.00, 10.00),
-  ('100008-100001', 99.90, 0.01, 98.90, 1.10, 99.60, 1.40)
-)
-INSERT INTO 
-    buzz.attendance
-(
-	StudentSchoolKey,
-  ReportedAsPresentAtSchool,
-  ReportedAsAbsentFromSchool,
-  ReportedAsPresentAtHomeRoom,
-  ReportedAsAbsentFromHomeRoom,
-  ReportedAsIsPresentInAllSections,
-  ReportedAsAbsentFromAnySection
-)
-SELECT
-  source.column1,
-  source.column2,
-  source.column3,
-  source.column4,
-  source.column5,
-  source.column6,
-  source.column7
-FROM
-    source
-ON CONFLICT DO NOTHING;

--- a/EdFi.Buzz.Database/migrations/sample-data/sqls/20201210143705-attendance-down.sql
+++ b/EdFi.Buzz.Database/migrations/sample-data/sqls/20201210143705-attendance-down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DELETE FROM buzz.attendance;

--- a/EdFi.Buzz.Database/migrations/sample-data/sqls/20201210143705-attendance-up.sql
+++ b/EdFi.Buzz.Database/migrations/sample-data/sqls/20201210143705-attendance-up.sql
@@ -1,0 +1,39 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+-- STUDENT ATTENDANCE
+
+WITH source AS (VALUES
+  ('100001-100001', 98.10, 1.90, 94.50, 5.50, 96.30, 3.70),
+  ('100002-100001', 92.60, 7.40, 95.00, 5.00, 96.60, 3.40),
+  ('100003-100001', 93.90, 6.10, 94.20, 5.80, 96.70, 3.30),
+  ('100004-100001', 91.90, 8.10, 99.80, 1.20, 98.40, 1.60),
+  ('100005-100001', 92.20, 7.80, 89.90, 10.10, 97.50, 2.50),
+  ('100006-100001', 90.90, 9.10, 91.40, 8.60, 97.70, 2.30),
+  ('100007-100001', 97.40, 2.60, 98.10, 1.90, 90.00, 10.00),
+  ('100008-100001', 99.90, 0.01, 98.90, 1.10, 99.60, 1.40)
+)
+INSERT INTO 
+  buzz.attendance
+(
+  StudentSchoolKey,
+  ReportedAsPresentAtSchool,
+  ReportedAsAbsentFromSchool,
+  ReportedAsPresentAtHomeRoom,
+  ReportedAsAbsentFromHomeRoom,
+  ReportedAsIsPresentInAllSections,
+  ReportedAsAbsentFromAnySection
+)
+SELECT
+  source.column1,
+  source.column2,
+  source.column3,
+  source.column4,
+  source.column5,
+  source.column6,
+  source.column7
+FROM
+  source
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
… data.

### The problem
The problem is simply that the demo site doesn't have attendance data.

### Testing
After reviewing the problem. I am pretty sure to know what happened. As the screenshot in the Jira ticket shows, when we implemented the ETL part for chronic absenteeism and we added data to the sample data, we didn't create a new migration and instead we modified the existing one. Since each migration is executed once, this new attendance data was never inserted in the database.

So, the solution would be just change 20201022195215-adds-sample-data-up.sql to its original state (before FIF-352 was merged), and create a new migration for the attendance sample data.