### PR TITLE
[FIF-393] Fix admin survey load screen bug

### DIFF
--- a/EdFi.Buzz.UI/src/Feature/AdminSurvey/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/AdminSurvey/index.tsx
@@ -160,8 +160,7 @@ export const AdminSurvey: FunctionComponent<AdminSurveyComponentProps> = (props:
   const surveyFilterRef = React.createRef<HTMLInputElement>();
 
   useEffect(() => {
-    SetAppMounted(true);
-    if(appMounted){
+    if(!appMounted){
       if (!surveyFilteredList || surveyFilteredList.length === 0) {
         props.api.survey.getSurveyStatus(
           props.api.authentication.currentUserValue.teacher.staffkey, null)
@@ -172,7 +171,7 @@ export const AdminSurvey: FunctionComponent<AdminSurveyComponentProps> = (props:
       }
     }
     return () => {
-      SetAppMounted(false);
+      SetAppMounted(true);
     };
   }, [props.api.authentication.currentUserValue.teacher.staffkey,
     props.api.survey,

--- a/EdFi.Buzz.UI/src/Feature/AdminSurvey/index.tsx
+++ b/EdFi.Buzz.UI/src/Feature/AdminSurvey/index.tsx
@@ -151,6 +151,7 @@ const StyledTextParent = styled.div`
 export const AdminSurvey: FunctionComponent<AdminSurveyComponentProps> = (props: AdminSurveyComponentProps) => {
   document.title = 'EdFi Buzz: Admin Surveys';
 
+  const [appMounted, SetAppMounted] = useState(false);
   const [surveyFilteredList, setsurveyFilteredList] = useState([] as SurveyStatus[]);
   const [surveyList, setsurveyList] = useState([] as SurveyStatus[]);
   const [surveyToDelete, setsurveyToDelete] = useState(null as number);
@@ -159,7 +160,7 @@ export const AdminSurvey: FunctionComponent<AdminSurveyComponentProps> = (props:
   const surveyFilterRef = React.createRef<HTMLInputElement>();
 
   useEffect(() => {
-    let appMounted=true;
+    SetAppMounted(true);
     if(appMounted){
       if (!surveyFilteredList || surveyFilteredList.length === 0) {
         props.api.survey.getSurveyStatus(
@@ -171,7 +172,7 @@ export const AdminSurvey: FunctionComponent<AdminSurveyComponentProps> = (props:
       }
     }
     return () => {
-      appMounted=false;
+      SetAppMounted(false);
     };
   }, [props.api.authentication.currentUserValue.teacher.staffkey,
     props.api.survey,


### PR DESCRIPTION
# OVERVIEW

The Admin Survey page has a bug when loading. The new spinner widget shows but nothing loads. When you open the Developer Tools console or have the API loaded in a console, you can see a loop of requests to our graphql endpoint firing in rapid succession.

Additionally, the page will throw an exception if there are no surveys in the database.

# EXPECTED RESULT

The page should load without issue regardless of how many surveys are in the database.


# TESTING STEPS

## With or without survey data present

Given that you are an admin survey loader enabled user and there are survey records,
When click the Admin Surveys menu link as an admin survey user,
It should show the spinner briefly 
And then it should load the page

> NOTE: To remove data, run the following SQL:
```sql
DELETE FROM buzz.studentsurveyanswer;
DELETE FROM buzz.studentsurvey;
DELETE FROM buzz.surveyquestion;
DELETE FROM buzz.survey;
DELETE FROM buzz.surveystatus;
```


## RESOLUTION 

The appMounted variable needs to be set outside the scope of Hooks to prevent loop.